### PR TITLE
Bug Fix: YEARS.BETWEEN not calculating correctly for same month

### DIFF
--- a/src/main/java/javax/time/calendrical/LocalDateTimeUnit.java
+++ b/src/main/java/javax/time/calendrical/LocalDateTimeUnit.java
@@ -303,7 +303,7 @@ public enum LocalDateTimeUnit implements PeriodUnit {
             case HALF_YEARS: return MONTHS.calculateBetweenForDate(date1, date2) / 6;
             case YEARS: {
                 long years = ((long) date2.getYear()) - date1.getYear();  // no overflow
-                if (date2.getMonthValue() <= date1.getMonthValue() || (date2.getMonthValue() == date1.getMonthValue() && date2.getDayOfMonth() <= date1.getDayOfMonth())) {
+                if (date2.getMonthValue() < date1.getMonthValue() || (date2.getMonthValue() == date1.getMonthValue() && date2.getDayOfMonth() <= date1.getDayOfMonth())) {
                     years--;
                 }
                 return years;

--- a/src/test/java/javax/time/calendrical/TestLocalDateTimeUnit.java
+++ b/src/test/java/javax/time/calendrical/TestLocalDateTimeUnit.java
@@ -1,0 +1,35 @@
+package javax.time.calendrical;
+
+import static org.testng.Assert.assertEquals;
+
+import static javax.time.calendrical.LocalDateTimeUnit.YEARS;
+
+import javax.time.LocalDate;
+import javax.time.Month;
+
+import org.testng.annotations.Test;
+
+@Test
+public class TestLocalDateTimeUnit {
+
+	public void testYearsBetweenInSameMonth() {
+		LocalDate begin = LocalDate.of(1939, Month.SEPTEMBER, 1);
+		LocalDate end = LocalDate.of(1945, Month.SEPTEMBER, 2);
+		
+		assertEquals( 6 ,YEARS.between(begin, end).getAmountInt());
+	}
+	
+	public void testYearsBetweenInMonthAfter() {
+		LocalDate begin = LocalDate.of(1939, Month.SEPTEMBER, 1);
+		LocalDate end = LocalDate.of(1945, Month.OCTOBER, 2);
+		
+		assertEquals( 6 ,YEARS.between(begin, end).getAmountInt());
+	}
+	
+	public void testYearsBetweenInMonthBefore() {
+		LocalDate begin = LocalDate.of(1939, Month.SEPTEMBER, 1);
+		LocalDate end = LocalDate.of(1945, Month.AUGUST, 2);
+		
+		assertEquals( 5 ,YEARS.between(begin, end).getAmountInt());
+	}
+}


### PR DESCRIPTION
Hi Team,

Found a bug where YEARS.between(begin, end) was not calculating correctly in the case where the begin and end month are the same in different years.

Was caused by a <= rather than a <

Thanks,
Jim 
