### PR TITLE
#19 multi-unit Period; added LocalPeriod class plus tests

### DIFF
--- a/src-standard/test/java/javax/time/chrono/TestISODate.java
+++ b/src-standard/test/java/javax/time/chrono/TestISODate.java
@@ -94,7 +94,7 @@ public class TestISODate {
         assertEquals(test.extract(OffsetDate.class), null);
         assertEquals(test.extract(OffsetTime.class), null);
         assertEquals(test.extract(OffsetDateTime.class), null);
-        assertEquals(test.extract(ZonedDateTime.class), test);
+        assertEquals(test.extract(ZonedDateTime.class), null);
         assertEquals(test.extract(ZoneOffset.class), null);
         assertEquals(test.extract(ZoneId.class), null);
         assertEquals(test.extract(Instant.class), null);

--- a/src/main/java/javax/time/LocalPeriod.java
+++ b/src/main/java/javax/time/LocalPeriod.java
@@ -1,0 +1,1135 @@
+/*
+ * Copyright (c) 2008-2012, Stephen Colebourne & Michael Nascimento Santos
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of JSR-310 nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package javax.time;
+
+import static javax.time.calendrical.LocalPeriodUnit.DAYS;
+import static javax.time.calendrical.LocalPeriodUnit.HOURS;
+import static javax.time.calendrical.LocalPeriodUnit.MINUTES;
+import static javax.time.calendrical.LocalPeriodUnit.MONTHS;
+import static javax.time.calendrical.LocalPeriodUnit.NANOS;
+import static javax.time.calendrical.LocalPeriodUnit.SECONDS;
+import static javax.time.calendrical.LocalPeriodUnit.YEARS;
+
+import java.io.Serializable;
+import javax.time.calendrical.DateTime;
+import javax.time.calendrical.LocalPeriodUnit;
+
+import javax.time.chrono.ISOChronology;
+import javax.time.calendrical.PeriodUnit;
+import javax.time.format.CalendricalParseException;
+
+/**
+ * An immutable period consisting of the ISO-8601 year, month, day, hour,
+ * minute, second and nanosecond units, such as '3 Months, 4 Days and 7 Hours'.
+ * <p>
+ * A period is a human-scale description of an amount of time.
+ * This class represents the 7 standard definitions from {@link ISOChronology}.
+ * The period units used are 'Years', 'Months', 'Days', 'Hours', 'Minutes',
+ * 'Seconds' and 'Nanoseconds'.
+ * <p>
+ * The {@code ISOChronology} defines a relationship between some of the units:
+ * <ul>
+ * <li>12 months in a year</li>
+ * <li>24 hours in a day (ignoring time-zones)</li>
+ * <li>60 minutes in an hour</li>
+ * <li>60 seconds in a minute</li>
+ * <li>1,000,000,000 nanoseconds in a second</li>
+ * </ul>
+ * <p>
+ * This class is immutable and thread-safe.
+ *
+ * @author Roger Riggs
+ * @author Stephen Colebourne
+ */
+public final class LocalPeriod
+        implements Serializable {
+
+    /**
+     * A constant for a period of zero.
+     */
+    public static final LocalPeriod ZERO = new LocalPeriod(0, 0, 0, 0, 0, 0, 0);
+    /**
+     * Serialization version.
+     */
+    private static final long serialVersionUID = 1L;
+    /**
+     * The number of years.
+     */
+    private final int years;
+    /**
+     * The number of months.
+     */
+    private final int months;
+    /**
+     * The number of days.
+     */
+    private final int days;
+    /**
+     * The number of hours.
+     */
+    private final int hours;
+    /**
+     * The number of minutes.
+     */
+    private final int minutes;
+    /**
+     * The number of seconds.
+     */
+    private final int seconds;
+    /**
+     * The number of nanoseconds.
+     */
+    private final long nanos;
+
+    //-----------------------------------------------------------------------
+    /**
+     * Obtains a {@code LocalPeriod} from date-based and time-based fields.
+     * <p>
+     * This creates an instance based on years, months, days, hours, minutes and seconds.
+     *
+     * @param years  the amount of years, may be negative
+     * @param months  the amount of months, may be negative
+     * @param days  the amount of days, may be negative
+     * @param hours  the amount of hours, may be negative
+     * @param minutes  the amount of minutes, may be negative
+     * @param seconds  the amount of seconds, may be negative
+     * @return the period, not null
+     */
+    public static LocalPeriod of(int years, int months, int days, int hours, int minutes, int seconds) {
+        return of(years, months, days, hours, minutes, seconds, 0);
+    }
+
+    /**
+     * Obtains a {@code LocalPeriod} from date-based and time-based fields.
+     * <p>
+     * This creates an instance based on years, months, days, hours, minutes, seconds and nanoseconds.
+     * The resulting period will have normalized seconds and nanoseconds.
+     *
+     * @param years  the amount of years, may be negative
+     * @param months  the amount of months, may be negative
+     * @param days  the amount of days, may be negative
+     * @param hours  the amount of hours, may be negative
+     * @param minutes  the amount of minutes, may be negative
+     * @param seconds  the amount of seconds, may be negative
+     * @param nanos  the amount of nanos, may be negative
+     * @return the period, not null
+     */
+    public static LocalPeriod of(int years, int months, int days, int hours, int minutes, int seconds, long nanos) {
+        if ((years | months | days | hours | minutes | seconds | nanos) == 0) {
+            return ZERO;
+        }
+        return new LocalPeriod(years, months, days, hours, minutes, seconds, nanos);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Obtains a {@code LocalPeriod} from date-based fields.
+     * <p>
+     * This creates an instance based on years, months and days.
+     *
+     * @param years  the amount of years, may be negative
+     * @param months  the amount of months, may be negative
+     * @param days  the amount of days, may be negative
+     * @return the period, not null
+     */
+    public static LocalPeriod ofDate(int years, int months, int days) {
+        return of(years, months, days, 0, 0, 0, 0);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Obtains a {@code LocalPeriod} from time-based fields.
+     * <p>
+     * This creates an instance based on hours, minutes and seconds.
+     *
+     * @param hours  the amount of hours, may be negative
+     * @param minutes  the amount of minutes, may be negative
+     * @param seconds  the amount of seconds, may be negative
+     * @return the period, not null
+     */
+    public static LocalPeriod ofTime(int hours, int minutes, int seconds) {
+        return of(0, 0, 0, hours, minutes, seconds, 0);
+    }
+
+    /**
+     * Obtains a {@code LocalPeriod} from time-based fields.
+     * <p>
+     * This creates an instance based on hours, minutes, seconds and nanoseconds.
+     *
+     * @param hours  the amount of hours, may be negative
+     * @param minutes  the amount of minutes, may be negative
+     * @param seconds  the amount of seconds, may be negative
+     * @param nanos  the amount of nanos, may be negative
+     * @return the period, not null
+     */
+    public static LocalPeriod ofTime(int hours, int minutes, int seconds, long nanos) {
+        return of(0, 0, 0, hours, minutes, seconds, nanos);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Obtains a {@code LocalPeriod} from an amount and unit.
+     * <p>
+     * The parameters represent the two parts of a phrase like '6 Days'.
+     * <p>
+     * A {@code LocalPeriod} supports 7 units, years, months, days, hours,
+     * minutes, seconds and nanoseconds. The unit must be one of these,
+     * the units quarter years, half years, are converted to equivalent months,
+     * and the units for decades, centuries, and millennia are converted to
+     * equivalent years.
+     *
+     * @param amount  the amount of the period, measured in terms of the unit, positive or negative
+     * @param unit  the unit that the period is measured in, not null
+     * @return the period, not null
+     * @throws CalendricalException if the unit is not supported
+     */
+    public static LocalPeriod of(long amount, PeriodUnit unit) {
+        DateTimes.checkNotNull(unit, "PeriodUnit must not be null");
+        if (unit instanceof LocalPeriodUnit) {
+            LocalPeriodUnit lpu = (LocalPeriodUnit)unit;
+            switch (lpu) {
+                case MILLENNIA:
+                    return LocalPeriod.ofDate(DateTimes.safeToInt(amount * 1000), 0, 0);
+                case CENTURIES:
+                    return LocalPeriod.ofDate(DateTimes.safeToInt(amount * 100), 0, 0);
+                case DECADES:
+                    return LocalPeriod.ofDate(DateTimes.safeToInt(amount * 10), 0, 0);
+                case YEARS:
+                case WEEK_BASED_YEARS:
+                    return LocalPeriod.ofDate(DateTimes.safeToInt(amount), 0, 0);
+                case HALF_YEARS:
+                    return LocalPeriod.ofDate(0, DateTimes.safeToInt(amount * 6), 0);
+                case QUARTER_YEARS:
+                    return LocalPeriod.ofDate(0, DateTimes.safeToInt(amount * 3), 0);
+                case MONTHS:
+                    return LocalPeriod.ofDate(0, DateTimes.safeToInt(amount), 0);
+                case WEEKS:
+                    return LocalPeriod.ofDate(0, 0, DateTimes.safeToInt(amount * 7));
+                case DAYS:
+                    return LocalPeriod.ofDate(0, 0, DateTimes.safeToInt(amount));
+                case HALF_DAYS:
+                    return LocalPeriod.ofTime(DateTimes.safeToInt(amount * 12), 0, 0, 0);
+                case HOURS:
+                    return LocalPeriod.ofTime(DateTimes.safeToInt(amount), 0, 0, 0);
+                case MINUTES:
+                    return LocalPeriod.ofTime(0, DateTimes.safeToInt(amount), 0, 0);
+                case SECONDS:
+                    return LocalPeriod.ofTime(0, 0, DateTimes.safeToInt(amount), 0);
+                case MILLIS:
+                    return LocalPeriod.ofTime(0, 0, 0, DateTimes.safeToInt(amount * 1000000L));
+                case MICROS:
+                    return LocalPeriod.ofTime(0, 0, 0, DateTimes.safeToInt(amount * 1000L));
+                case NANOS:
+                    return LocalPeriod.ofTime(0, 0, 0, amount);
+                default:
+                    // Fall through to handle throw unsupported PeriodUnit
+            }
+        }
+        throw new CalendricalException("Cannot create a LocalPeriod of the unit " + unit);
+    }
+
+    /**
+     * Obtains a {@code LocalPeriod} from a Period.
+     * <p>
+     * A {@code LocalPeriod} supports 7 units, years, months, days, hours,
+     * minutes, seconds and nanoseconds. The unit must be one of these,
+     * the units quarter years, half years, are converted to equivalent months,
+     * and the units for decades, centuries, and millennia are converted to
+     * equivalent years.
+     *
+     * @param amount  the amount of the period, measured in terms of the unit, positive or negative
+     * @param unit  the unit that the period is measured in, not null
+     * @return the period, not null
+     * @throws CalendricalException if the unit is not supported
+     */
+    public static LocalPeriod of(Period period) {
+        DateTimes.checkNotNull(period, "Period must not be null");
+        return of(period.getAmount(), period.getUnit());
+
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Obtains a {@code LocalPeriod} from a {@code Duration}.
+     * <p>
+     * The created period will have normalized values for the hours, minutes,
+     * seconds and nanoseconds fields. The years, months and days fields will be zero.
+     * <p>
+     * To populate the days field, call {@link #normalizedWith24HourDays()} on the created period.
+     *
+     * @param duration  the duration to create from, not null
+     * @return the {@code PeriodFields} instance, not null
+     * @throws ArithmeticException if the result exceeds the supported period range
+     */
+    public static LocalPeriod of(Duration duration) {
+        DateTimes.checkNotNull(duration, "Duration must not be null");
+        if (duration.isZero()) {
+            return ZERO;
+        }
+        int hours = DateTimes.safeToInt(duration.getSeconds() / 3600);
+        int amount = (int) (duration.getSeconds() % 3600L);
+        return new LocalPeriod(0, 0, 0, hours, (amount / 60), (amount % 60), duration.getNano());
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Returns a {@code LocalPeriod} consisting of the number of years, months, days,
+     * hours, minutes, seconds, and nanoseconds between two {@code DateTime} instances.
+     * <p>
+     * The start date is included, but the end date is not. Only whole years count.
+     * For example, from {@code 2010-01-15} to {@code 2011-03-18} is one year, two months and three days.
+     * <p>
+     * The result of this method can be a negative period if the end is before the start.
+     * The negative sign will be the same in each of year, month and day.
+     * <p>
+     * Adding the result of this method to the start date will always yield the end date.
+     *
+     * @param start  the start date, inclusive, not null
+     * @param end  the end date, exclusive, not null
+     * @return the period in days, not null
+     * @throws CalendricalException if {@code LocalDate} and {@code LocalTime}
+     *      cannot be extracted from the {@code start} and {@code end}
+     * @throws ArithmeticException if the period exceeds the supported range
+     */
+    public static LocalPeriod between(DateTime start, DateTime end) {
+        LocalPeriod delta = LocalPeriod.ZERO;
+        
+        LocalDate date1 = start.extract(LocalDate.class);
+        LocalTime time1 = start.extract(LocalTime.class);
+        LocalDate date2 = end.extract(LocalDate.class);
+        LocalTime time2 = end.extract(LocalTime.class);
+
+        if (date1 != null && date2 != null) {
+            delta.plus(between(date1, date2));
+        } else {
+            if (date1 != null || date2 != null) {
+                throw new CalendricalException("LocalDate not available for between");
+            }
+        }
+        if (time1 != null && time2 != null) {
+            delta.plus(between(time1, time2));
+        } else {
+            if (time1 != null || time2 != null) {
+                throw new CalendricalException("LocalTime not available for between");
+            }
+        }
+        return delta;
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Obtains a {@code LocalPeriod} consisting of the number of years, months,
+     * and days between two dates.
+     * <p>
+     * The start date is included, but the end date is not. Only whole years count.
+     * For example, from {@code 2010-01-15} to {@code 2011-03-18} is one year, two months and three days.
+     * <p>
+     * The result of this method can be a negative period if the end is before the start.
+     * The negative sign will be the same in each of year, month and day.
+     * <p>
+     * Adding the result of this method to the start date will always yield the end date.
+     *
+     * @param startDate  the start date, inclusive, not null
+     * @param endDate  the end date, exclusive, not null
+     * @return the period in days, not null
+     * @throws ArithmeticException if the period exceeds the supported range
+     */
+    public static LocalPeriod between(LocalDate startDate, LocalDate endDate) {
+        long startMonth = startDate.getYear() * 12L + startDate.getMonth().ordinal();  // safe
+        long endMonth = endDate.getYear() * 12L + endDate.getMonth().ordinal();  // safe
+        long totalMonths = endMonth - startMonth;  // safe
+        int days = endDate.getDayOfMonth() - startDate.getDayOfMonth();
+        if (totalMonths > 0 && days < 0) {
+            totalMonths--;
+            LocalDate calcDate = startDate.plusMonths(totalMonths);
+            days = (int) (endDate.toEpochDay() - calcDate.toEpochDay());  // safe
+        } else if (totalMonths < 0 && days > 0) {
+            totalMonths++;
+            days -= endDate.lengthOfMonth();
+        }
+        long years = totalMonths / 12;  // safe
+        int months = (int) (totalMonths % 12);  // safe
+        return ofDate(DateTimes.safeToInt(years), months, days);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Obtains a {@code LocalPeriod} consisting of the number of hours, minutes,
+     * seconds, and nanoseconds between two times.
+     * <p>
+     * The start time is included, but the end time is not.
+     * For example, from {@code 13:45.30.123456789} to {@code 14:50.00}
+     * {@code 01:05.30.123456789}.
+     * <p>
+     * The result of this method can be a negative period if the end is before the start.
+     * The negative sign will be the same in each of year, month and day.
+     * <p>
+     * Adding the result of this method to the start time will always yield the end time.
+     *
+     * @param startDate  the start date, inclusive, not null
+     * @param endDate  the end date, exclusive, not null
+     * @return the period in days, not null
+     * @throws ArithmeticException if the period exceeds the supported range
+     */
+    public static LocalPeriod between(LocalTime startTime, LocalTime endTime) {
+        long delta = endTime.toNanoOfDay() - startTime.toNanoOfDay();
+
+        long nanos = DateTimes.floorMod(delta, 1000000000L);
+        long total = DateTimes.floorDiv(delta, 1000000000L);  // safe from overflow
+        int seconds = DateTimes.floorMod(total, 60);
+        total  = DateTimes.floorDiv(total, 60);
+        int minutes = DateTimes.floorMod(total, 60);
+        total  = DateTimes.floorDiv(total, 60);
+        int hours = DateTimes.safeToInt(total);
+        return LocalPeriod.ofTime(hours, minutes, seconds, nanos);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Obtains a {@code LocalPeriod} from a text string such as {@code PnYnMnDTnHnMn.nS}.
+     * <p>
+     * This will parse the string produced by {@code toString()} which is
+     * a subset of the ISO-8601 period format {@code PnYnMnDTnHnMn.nS}.
+     * <p>
+     * The string consists of a series of numbers with a suffix identifying their meaning.
+     * The values, and suffixes, must be in the sequence year, month, day, hour, minute, second.
+     * Any of the number/suffix pairs may be omitted providing at least one is present.
+     * If the period is zero, the value is normally represented as {@code PT0S}.
+     * The numbers must consist of ASCII digits.
+     * Any of the numbers may be negative. Negative zero is not accepted.
+     * The number of nanoseconds is expressed as an optional fraction of the seconds.
+     * There must be at least one digit before any decimal point.
+     * There must be between 1 and 9 inclusive digits after any decimal point.
+     * The letters will all be accepted in upper or lower case.
+     * The decimal point may be either a dot or a comma.
+     *
+     * @param text  the text to parse, not null
+     * @return the parsed period, not null
+     * @throws CalendricalParseException if the text cannot be parsed to a LocalPeriod
+     */
+    public static LocalPeriod parse(final CharSequence text) {
+        DateTimes.checkNotNull(text, "Text to parse must not be null");
+        return new PeriodParser(text).parse();
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Constructor.
+     *
+     * @param years  the amount
+     * @param months  the amount
+     * @param days  the amount
+     * @param hours  the amount
+     * @param minutes  the amount
+     * @param seconds  the amount
+     * @param nanos  the amount
+     */
+    private LocalPeriod(int years, int months, int days, int hours, int minutes, int seconds, long nanos) {
+        this.years = years;
+        this.months = months;
+        this.days = days;
+        this.hours = hours;
+        this.minutes = minutes;
+        this.seconds = seconds;
+        this.nanos = nanos;
+    }
+
+    /**
+     * Resolves singletons.
+     *
+     * @return the resolved instance
+     */
+    private Object readResolve() {
+        if ((years | months | days | hours | minutes | seconds | nanos) == 0) {
+            return ZERO;
+        }
+        return this;
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Checks if this period is zero-length.
+     *
+     * @return true if this period is zero-length
+     */
+    public boolean isZero() {
+        return (this == ZERO);
+    }
+
+    /**
+     * Checks if this period is fully positive, excluding zero.
+     * <p>
+     * This checks whether all the amounts in the period are positive,
+     * defined as greater than zero.
+     *
+     * @return true if this period is fully positive excluding zero
+     */
+    public boolean isPositive() {
+        return ((years | months | days | hours | minutes | seconds | nanos) > 0);
+    }
+
+    /**
+     * Checks if this period is fully positive, including zero.
+     * <p>
+     * This checks whether all the amounts in the period are positive,
+     * defined as greater than or equal to zero.
+     *
+     * @return true if this period is fully positive including zero
+     */
+    public boolean isPositiveOrZero() {
+        return ((years | months | days | hours | minutes | seconds | nanos) >= 0);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Gets the amount of years of this period, if any.
+     *
+     * @return the amount of years of this period
+     */
+    public int getYears() {
+        return years;
+    }
+
+    /**
+     * Gets the amount of months of this period, if any.
+     *
+     * @return the amount of months of this period
+     */
+    public int getMonths() {
+        return months;
+    }
+
+    /**
+     * Gets the amount of days of this period, if any.
+     *
+     * @return the amount of days of this period
+     */
+    public int getDays() {
+        return days;
+    }
+
+    /**
+     * Gets the amount of hours of this period, if any.
+     *
+     * @return the amount of hours of this period
+     */
+    public int getHours() {
+        return hours;
+    }
+
+    /**
+     * Gets the amount of minutes of this period, if any.
+     *
+     * @return the amount of minutes of this period
+     */
+    public int getMinutes() {
+        return minutes;
+    }
+
+    /**
+     * Gets the amount of seconds of this period, if any.
+     *
+     * @return the amount of seconds of this period
+     */
+    public int getSeconds() {
+        return seconds;
+    }
+
+    /**
+     * Gets the amount of nanoseconds of this period, if any.
+     *
+     * @return the amount of nanoseconds of this period
+     */
+    public long getNanos() {
+        return nanos;
+    }
+
+    /**
+     * Gets the amount of nanoseconds of this period safely converted
+     * to an {@code int}.
+     *
+     * @return the amount of nanoseconds of this period
+     * @throws ArithmeticException if the number of nanoseconds exceeds the capacity of an {@code int}
+     */
+    public int getNanosInt() {
+        return DateTimes.safeToInt(nanos);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Returns a copy of this period with the specified amount of years.
+     * <p>
+     * This method will only affect the years field.
+     * All other fields are left untouched.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param years  the years to represent
+     * @return a {@code LocalPeriod} based on this period with the requested years, not null
+     */
+    public LocalPeriod withYears(int years) {
+        if (years == this.years) {
+            return this;
+        }
+        return of(years, months, days, hours, minutes, seconds, nanos);
+    }
+
+    /**
+     * Returns a copy of this period with the specified amount of months.
+     * <p>
+     * This method will only affect the months field.
+     * All other fields are left untouched.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param months  the months to represent
+     * @return a {@code LocalPeriod} based on this period with the requested months, not null
+     */
+    public LocalPeriod withMonths(int months) {
+        if (months == this.months) {
+            return this;
+        }
+        return of(years, months, days, hours, minutes, seconds, nanos);
+    }
+
+    /**
+     * Returns a copy of this period with the specified amount of days.
+     * <p>
+     * This method will only affect the days field.
+     * All other fields are left untouched.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param days  the days to represent
+     * @return a {@code LocalPeriod} based on this period with the requested days, not null
+     */
+    public LocalPeriod withDays(int days) {
+        if (days == this.days) {
+            return this;
+        }
+        return of(years, months, days, hours, minutes, seconds, nanos);
+    }
+
+    /**
+     * Returns a copy of this period with the specified amount of hours.
+     * <p>
+     * This method will only affect the hours field.
+     * All other fields are left untouched.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param hours  the hours to represent
+     * @return a {@code LocalPeriod} based on this period with the requested hours, not null
+     */
+    public LocalPeriod withHours(int hours) {
+        if (hours == this.hours) {
+            return this;
+        }
+        return of(years, months, days, hours, minutes, seconds, nanos);
+    }
+
+    /**
+     * Returns a copy of this period with the specified amount of minutes.
+     * <p>
+     * This method will only affect the minutes field.
+     * All other fields are left untouched.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param minutes  the minutes to represent
+     * @return a {@code LocalPeriod} based on this period with the requested minutes, not null
+     */
+    public LocalPeriod withMinutes(int minutes) {
+        if (minutes == this.minutes) {
+            return this;
+        }
+        return of(years, months, days, hours, minutes, seconds, nanos);
+    }
+
+    /**
+     * Returns a copy of this period with the specified amount of seconds.
+     * <p>
+     * This method will only affect the seconds field.
+     * All other fields are left untouched.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param seconds  the seconds to represent
+     * @return a {@code LocalPeriod} based on this period with the requested seconds, not null
+     */
+    public LocalPeriod withSeconds(int seconds) {
+        if (seconds == this.seconds) {
+            return this;
+        }
+        return of(years, months, days, hours, minutes, seconds, nanos);
+    }
+
+    /**
+     * Returns a copy of this period with the specified amount of nanoseconds.
+     * <p>
+     * This method will only affect the nanoseconds field.
+     * All other fields are left untouched.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param nanos  the nanoseconds to represent
+     * @return a {@code LocalPeriod} based on this period with the requested nanoseconds, not null
+     */
+    public LocalPeriod withNanos(long nanos) {
+        if (nanos == this.nanos) {
+            return this;
+        }
+        return of(years, months, days, hours, minutes, seconds, nanos);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Returns a copy of this period with the specified period added.
+     * The result is not normalized.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param other  the period to add, not null
+     * @return a {@code LocalPeriod} based on this period with the requested period added, not null
+     * @throws ArithmeticException if the capacity of any field is exceeded
+     */
+    public LocalPeriod plus(LocalPeriod other) {
+        return of(
+                DateTimes.safeAdd(years, other.years),
+                DateTimes.safeAdd(months, other.months),
+                DateTimes.safeAdd(days, other.days),
+                DateTimes.safeAdd(hours, other.hours),
+                DateTimes.safeAdd(minutes, other.minutes),
+                DateTimes.safeAdd(seconds, other.seconds),
+                DateTimes.safeAdd(nanos, other.nanos));
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Returns a copy of this LocalPeriod with the specified period added.
+     * The result is not normalized.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param period  the period to add, not null
+     * @return a {@code LocalPeriod} based on this period with the requested period added, not null
+     * @throws CalendricalException if the unit is not supported by LocalPeriod
+     * @throws ArithmeticException if the capacity of any field is exceeded
+     */
+    public LocalPeriod plus(Period period) {
+        return plus(of(period));
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Returns a copy of this period with the specified PeriodUnit value added.
+     * The result is not normalized.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param amount  the years to add, positive or negative
+     * @param unit the PeriodUnit of the amount
+     * @return a {@code LocalPeriod} based on this period with the requested years added, not null
+     * @throws ArithmeticException if the capacity of an {@code int} is exceeded
+     */
+    public LocalPeriod plus(long amount, PeriodUnit unit) {
+        DateTimes.checkNotNull(unit, "PeriodUnit must not be null");
+        if (amount == 0) {
+            return this;
+        }
+        if (unit instanceof LocalPeriodUnit) {
+            int nvalue = DateTimes.safeToInt(amount);
+            switch((LocalPeriodUnit)unit) {
+                case NANOS: return of(years, months, days, hours, minutes, seconds, DateTimes.safeAdd(nanos,  nvalue));
+                case MICROS: return of(years, months, days, hours, minutes, seconds, DateTimes.safeToInt(nvalue * 1000L +  nanos));
+                case MILLIS: return of(years, months, days, hours, minutes, seconds, DateTimes.safeToInt(nvalue * 1000000L + nanos));
+                case SECONDS: return of(years, months, days, hours, minutes, DateTimes.safeAdd(seconds, nvalue), nanos);
+                case MINUTES: return of(years, months, days, hours, DateTimes.safeAdd(minutes, nvalue), seconds, nanos);
+                case HOURS: return of(years, months, days, DateTimes.safeAdd(hours,  nvalue), minutes, seconds, nanos);
+                case HALF_DAYS: return of(years, months, days, DateTimes.safeToInt(nvalue * 12L + hours), minutes, seconds, nanos);
+                case DAYS: return of(years, months, DateTimes.safeAdd(days, nvalue), hours, minutes, seconds, nanos);
+                case WEEKS: return of(years, months, DateTimes.safeToInt(nvalue * 7L + days), hours, minutes, seconds, nanos);
+                case MONTHS: return of(years, DateTimes.safeAdd(months, nvalue), days, hours, minutes, seconds, nanos);
+                case QUARTER_YEARS: return of(years, DateTimes.safeToInt(nvalue * 3L + months), days, hours, minutes, seconds, nanos);
+                case HALF_YEARS: return of(years, DateTimes.safeToInt(nvalue * 6L + months), days, hours, minutes, seconds, nanos);
+                case WEEK_BASED_YEARS:
+                case YEARS: return of(DateTimes.safeAdd(years, nvalue), months, days, hours, minutes, seconds, nanos);
+                case DECADES: return LocalPeriod.ofDate(DateTimes.safeToInt(amount * 10L + years), 0, 0);
+                case CENTURIES: return LocalPeriod.ofDate(DateTimes.safeToInt(amount * 100L + years), 0, 0);
+                case MILLENNIA: return LocalPeriod.ofDate(DateTimes.safeToInt(amount * 1000L + years), 0, 0);
+                default:
+                    // Fall through to handle throw unsupported PeriodUnit
+            }
+        }
+        throw new CalendricalException("Cannot create a LocalPeriod of the unit " + unit);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Returns a copy of this period with the specified PeriodUnit value subtracted.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param amount  the years to add, positive or negative
+     * @param unit the PeriodUnit of the amount
+     * @return a {@code LocalPeriod} based on this period with the requested years added, not null
+     * @throws ArithmeticException if the capacity of an {@code int} is exceeded
+     */
+    public LocalPeriod minus(long amount, PeriodUnit unit) {
+         return plus(DateTimes.safeNegate(amount), unit);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Returns a copy of this LocalPeriod with the specified period subtracted.
+     * The result is not normalized.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param period  the period to add, not null
+     * @return a {@code LocalPeriod} based on this period with the requested period added, not null
+     * @throws CalendricalException if the unit is not supported by LocalPeriod
+     * @throws ArithmeticException if the capacity of any field is exceeded
+     */
+    public LocalPeriod minus(Period period) {
+        return minus(of(period));
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Returns a copy of this period with the specified period subtracted.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param other  the period to subtract, not null
+     * @return a {@code LocalPeriod} based on this period with the requested period subtracted, not null
+     * @throws ArithmeticException if the capacity of any field is exceeded
+     */
+    public LocalPeriod minus(LocalPeriod other) {
+        DateTimes.checkNotNull(other, "LocalPeriod to add must not be null");
+        return of(
+                DateTimes.safeSubtract(years, other.years),
+                DateTimes.safeSubtract(months, other.months),
+                DateTimes.safeSubtract(days, other.days),
+                DateTimes.safeSubtract(hours, other.hours),
+                DateTimes.safeSubtract(minutes, other.minutes),
+                DateTimes.safeSubtract(seconds, other.seconds),
+                DateTimes.safeSubtract(nanos, other.nanos));
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Returns a new instance with each element in this period multiplied
+     * by the specified scalar.
+     *
+     * @param scalar  the scalar to multiply by, not null
+     * @return a {@code LocalPeriod} based on this period with the amounts multiplied by the scalar, not null
+     * @throws ArithmeticException if the capacity of any field is exceeded
+     */
+    public LocalPeriod multipliedBy(int scalar) {
+        if (this == ZERO || scalar == 1) {
+            return this;
+        }
+        return of(
+                DateTimes.safeMultiply(years, scalar),
+                DateTimes.safeMultiply(months, scalar),
+                DateTimes.safeMultiply(days, scalar),
+                DateTimes.safeMultiply(hours, scalar),
+                DateTimes.safeMultiply(minutes, scalar),
+                DateTimes.safeMultiply(seconds, scalar),
+                DateTimes.safeMultiply(nanos, scalar));
+    }
+
+    /**
+     * Returns a new instance with each element in this period divided
+     * by the specified value.
+     * <p>
+     * The implementation simply divides each separate field by the divisor
+     * using integer division.
+     *
+     * @param divisor  the value to divide by, not null
+     * @return a {@code LocalPeriod} based on this period with the amounts divided by the divisor, not null
+     * @throws ArithmeticException if dividing by zero
+     */
+    public LocalPeriod dividedBy(int divisor) {
+        if (divisor == 0) {
+            throw new ArithmeticException("Cannot divide by zero");
+        }
+        if (this == ZERO || divisor == 1) {
+            return this;
+        }
+        return of(
+                years / divisor, months / divisor, days / divisor,
+                hours / divisor, minutes / divisor, seconds / divisor, nanos / divisor);
+    }
+
+    /**
+     * Returns a new instance with each amount in this period negated.
+     *
+     * @return a {@code LocalPeriod} based on this period with the amounts negated, not null
+     * @throws ArithmeticException if any field has the minimum value
+     */
+    public LocalPeriod negated() {
+        return multipliedBy(-1);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Returns a copy of this period with all amounts normalized to the
+     * standard ranges for date-time fields.
+     * <p>
+     * Two normalizations occur, one for years and months, and one for
+     * hours, minutes, seconds and nanoseconds.
+     * Days are not normalized, as a day may vary in length at daylight savings cutover.
+     * For example, a period of {@code P1Y15M1DT28H61M} will be normalized to {@code P2Y3M1DT29H1M}.
+     * <p>
+     * Note that this method normalizes using ISO-8601:
+     * <ul>
+     * <li>12 months in a year</li>
+     * <li>60 minutes in an hour</li>
+     * <li>60 seconds in a minute</li>
+     * <li>1,000,000,000 nanoseconds in a second</li>
+     * </ul>
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @return a {@code LocalPeriod} based on this period with the amounts normalized, not null
+     * @throws ArithmeticException if the capacity of any field is exceeded
+     */
+    public LocalPeriod normalized() {
+        if (this == ZERO) {
+            return ZERO;
+        }
+        int years = DateTimes.safeAdd(this.years, DateTimes.floorDiv(this.months, 12));
+        int months = DateTimes.floorMod(this.months, 12);
+        long total = (this.hours * 60L * 60L) + (this.minutes * 60L) + this.seconds;  // safe from overflow
+        long nanos = DateTimes.floorMod(this.nanos, 1000000000L);
+        total += DateTimes.floorDiv(this.nanos, 1000000000L);  // safe from overflow
+        int seconds = DateTimes.floorMod(total, 60);
+        total  = DateTimes.floorDiv(total, 60);
+        int minutes = DateTimes.floorMod(total, 60);
+        total  = DateTimes.floorDiv(total, 60);
+        int hours = DateTimes.safeToInt(total);
+        return of(years, months, days, hours, minutes, seconds, nanos);
+    }
+
+    /**
+     * Returns a copy of this period with all amounts normalized to the
+     * standard ranges for date-time fields including the assumption that
+     * days are 24 hours long.
+     * <p>
+     * Two normalizations occur, one for years and months, and one for
+     * days, hours, minutes, seconds and nanoseconds.
+     * For example, a period of {@code P1Y15M1DT28H} will be normalized to {@code P2Y3M2DT4H}.
+     * <p>
+     * Note that this method normalizes using ISO-8601:
+     * <ul>
+     * <li>12 months in a year</li>
+     * <li>24 hours in a day</li>
+     * <li>60 minutes in an hour</li>
+     * <li>60 seconds in a minute</li>
+     * <li>1,000,000,000 nanoseconds in a second</li>
+     * </ul>
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @return a {@code LocalPeriod} based on this period with the amounts normalized, not null
+     * @throws ArithmeticException if the capacity of any field is exceeded
+     */
+    public LocalPeriod normalizedWith24HourDays() {
+        if (this == ZERO) {
+            return ZERO;
+        }
+        int years = DateTimes.safeAdd(this.years, DateTimes.floorDiv(this.months, 12));
+        int months = DateTimes.floorMod(this.months, 12);
+        long total = (this.hours * 60L * 60L) + (this.minutes * 60L) + this.seconds;  // safe from overflow
+        long nanos = DateTimes.floorMod(this.nanos, 1000000000L);
+        total += DateTimes.floorDiv(this.nanos, 1000000000L);  // safe from overflow
+        int seconds = DateTimes.floorMod(total, 60);
+        total  = DateTimes.floorDiv(total, 60);
+        int minutes = DateTimes.floorMod(total, 60);
+        total  = DateTimes.floorDiv(total, 60);
+        int hours = DateTimes.floorMod(total, 24);
+        total  = DateTimes.floorDiv(total, 24);
+        int days = DateTimes.safeToInt(this.days + total);  // safe from overflow
+        return of(years, months, days, hours, minutes, seconds, nanos);
+    }
+
+    /**
+     * Checks if the duration of this LocalPeriod is an estimate.
+     * <p>
+     * This method returns true if the duration is an estimate and false if it is
+     * accurate. Note that accurate/estimated ignores leap seconds.
+     * The duration of this LocalPeriod is estimated only if months and years
+     * are non-zero.
+     *
+     * @return true if the duration is estimated, false if accurate
+     */
+    boolean isDurationEstimated() {
+        return this.years != 0 || this.months != 0;
+    }
+
+    /**
+     * Calculates the duration of this period.
+     * <p>
+     * The calculation uses the days, hours, minutes, seconds and nanoseconds fields.
+     * If years or months are present an exception is thrown.
+     * <p>
+     * The duration is calculated using ISO-8601:
+     * <ul>
+     * <li>24 hours in a day</li>
+     * <li>60 minutes in an hour</li>
+     * <li>60 seconds in a minute</li>
+     * <li>1,000,000,000 nanoseconds in a second</li>
+     * </ul>
+     *
+     * @return a {@code Duration} equivalent to this period, not null
+     * @throws CalendricalException if the period cannot be converted as it contains years/months
+     */
+    public Duration toDuration() {
+        if ((years | months) > 0) {
+            throw new CalendricalException("Unable to convert period to duration as years/months are present: " + this);
+        }
+        long secs = ((days * 24L + hours) * 60L + minutes) * 60L + seconds;  // will not overflow
+        return Duration.ofSeconds(secs, nanos);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Checks if this period is equal to another period.
+     * <p>
+     * The comparison is based on the amounts held in the period.
+     *
+     * @param obj  the object to check, null returns false
+     * @return true if this is equal to the other period
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj instanceof LocalPeriod) {
+            LocalPeriod other = (LocalPeriod) obj;
+            return years == other.years && months == other.months && days == other.days &
+                    hours == other.hours && minutes == other.minutes &&
+                    seconds == other.seconds && nanos == other.nanos;
+        }
+        return false;
+    }
+
+    /**
+     * A hash code for this period.
+     *
+     * @return a suitable hash code
+     */
+    @Override
+    public int hashCode() {
+        // SPEC: Require unique hash code for all periods where fields within these inclusive bounds:
+        // years 0-31, months 0-11, days 0-31, hours 0-23, minutes 0-59, seconds 0-59
+        // IMPL: Ordered such that overflow from one field doesn't immediately affect the next field
+        // years 5 bits, months 4 bits, days 6 bits, hours 5 bits, minutes 6 bits, seconds 6 bits
+        return ((years << 27) | (years >>> 5)) ^
+                ((hours << 22) | (hours >>> 10)) ^
+                ((months << 18) | (months >>> 14)) ^
+                ((minutes << 12) | (minutes >>> 20)) ^
+                ((days << 6) | (days >>> 26)) ^ seconds ^ (((int) nanos) + 37);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Outputs this period as a {@code String}, such as {@code P6Y3M1DT12H}.
+     * <p>
+     * The output will be in the ISO-8601 period format.
+     *
+     * @return a string representation of this period, not null
+     */
+    @Override
+    public String toString() {
+        // TODO: toString doesn't match state nanos/secs
+        if (this == ZERO) {
+            return "PT0S";
+        } else {
+            StringBuilder buf = new StringBuilder();
+            buf.append('P');
+            if (years != 0) {
+                buf.append(years).append('Y');
+            }
+            if (months != 0) {
+                buf.append(months).append('M');
+            }
+            if (days != 0) {
+                buf.append(days).append('D');
+            }
+            if ((hours | minutes | seconds) != 0 || nanos != 0) {
+                buf.append('T');
+                if (hours != 0) {
+                    buf.append(hours).append('H');
+                }
+                if (minutes != 0) {
+                    buf.append(minutes).append('M');
+                }
+                if (seconds != 0 || nanos != 0) {
+                    if (nanos == 0) {
+                        buf.append(seconds).append('S');
+                    } else {
+                        long s = seconds + (nanos / 1000000000);
+                        long n = nanos % 1000000000;
+                        if (s < 0 && n > 0) {
+                            n -= 1000000000;
+                            s++;
+                        } else if (s > 0 && n < 0) {
+                            n += 1000000000;
+                            s--;
+                        }
+                        if (n < 0) {
+                            n = -n;
+                            if (s == 0) {
+                                buf.append('-');
+                            }
+                        }
+                        buf.append(s);
+                        int dotPos = buf.length();
+                        n += 1000000000;
+                        while (n % 10 == 0) {
+                            n /= 10;
+                        }
+                        buf.append(n);
+                        buf.setCharAt(dotPos, '.');
+                        buf.append('S');
+                    }
+                }
+            }
+            return buf.toString();
+        }
+    }
+
+}

--- a/src/main/java/javax/time/PeriodParser.java
+++ b/src/main/java/javax/time/PeriodParser.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright (c) 2009-2011, Stephen Colebourne & Michael Nascimento Santos
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of JSR-310 nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package javax.time;
+
+import javax.time.format.CalendricalParseException;
+
+/**
+ * A period parser that creates an instance of {@code Period} from a string.
+ * This parses the ISO-8601 period format {@code PnYnMnDTnHnMn.nS}.
+ * <p>
+ * This class is mutable and intended for use by a single thread.
+ *
+ * @author Darryl West
+ * @author Stephen Colebourne
+ */
+final class PeriodParser {
+
+    /**
+     * Used to validate the correct sequence of tokens.
+     */
+    private static final String TOKEN_SEQUENCE = "PYMDTHMS";
+    /**
+     * The standard string representing a zero period.
+     */
+    private static final String ZERO = "PT0S";
+
+    /**
+     * The number of years.
+     */
+    private int years;
+    /**
+     * The number of months.
+     */
+    private int months;
+    /**
+     * The number of days.
+     */
+    private int days;
+    /**
+     * The number of hours.
+     */
+    private int hours;
+    /**
+     * The number of minutes.
+     */
+    private int minutes;
+    /**
+     * The number of seconds.
+     */
+    private int seconds;
+    /**
+     * The number of nanoseconds.
+     */
+    private long nanos;
+    /**
+     * Whether the seconds were negative.
+     */
+    private boolean negativeSecs;
+    /**
+     * Parser position index.
+     */
+    private int index;
+    /**
+     * Original text.
+     */
+    private CharSequence text;
+
+    /**
+     * Constructor.
+     * 
+     * @param text  the text to parse, not null
+     */
+    PeriodParser(CharSequence text) {
+        this.text = text;
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Performs the parse.
+     * <p>
+     * This parses the text set in the constructor in the format PnYnMnDTnHnMn.nS.
+     *
+     * @return the created Period, not null
+     * @throws CalendricalParseException if the text cannot be parsed to a Period
+     */
+    LocalPeriod parse() {
+        // force to upper case and coerce the comma to dot
+        
+        String s = text.toString().toUpperCase().replace(',', '.');
+        // check for zero and skip parse
+        if (ZERO.equals(s)) {
+            return LocalPeriod.ZERO;
+        }
+        if (s.length() < 3 || s.charAt(0) != 'P') {
+            throw new CalendricalParseException("Period could not be parsed: " + text, text, 0);
+        }
+        validateCharactersAndOrdering(s, text);
+        
+        // strip off the leading P
+        String[] datetime = s.substring(1).split("T");
+        switch (datetime.length) {
+            case 2:
+                parseDate(datetime[0], 1);
+                parseTime(datetime[1], datetime[0].length() + 2);
+                break;
+            case 1:
+                parseDate(datetime[0], 1);
+                break;
+        }
+        return toPeriod();
+    }
+
+    private void parseDate(String s, int baseIndex) {
+        index = 0;
+        while (index < s.length()) {
+            String value = parseNumber(s);
+            if (index < s.length()) {
+                char c = s.charAt(index);
+                switch(c) {
+                    case 'Y': years = parseInt(value, baseIndex) ; break;
+                    case 'M': months = parseInt(value, baseIndex) ; break;
+                    case 'D': days = parseInt(value, baseIndex) ; break;
+                    default:
+                        throw new CalendricalParseException("Period could not be parsed, unrecognized letter '" +
+                                c + ": " + text, text, baseIndex + index);
+                }
+                index++;
+            }
+        }
+    }
+
+    private void parseTime(String s, int baseIndex) {
+        index = 0;
+        s = prepareTime(s, baseIndex);
+        while (index < s.length()) {
+            String value = parseNumber(s);
+            if (index < s.length()) {
+                char c = s.charAt(index);
+                switch(c) {
+                    case 'H': hours = parseInt(value, baseIndex) ; break;
+                    case 'M': minutes = parseInt(value, baseIndex) ; break;
+                    case 'S': seconds = parseInt(value, baseIndex) ; break;
+                    case 'N': nanos = parseNanos(value, baseIndex); break;
+                    default:
+                        throw new CalendricalParseException("Period could not be parsed, unrecognized letter '" +
+                                c + "': " + text, text, baseIndex + index);
+                }
+                index++;
+            }
+        }
+    }
+
+    private long parseNanos(String s, int baseIndex) {
+        if (s.length() > 9) {
+            throw new CalendricalParseException("Period could not be parsed, nanosecond range exceeded: " +
+                    text, text, baseIndex + index - s.length());
+        }
+        // pad to the right to create 10**9, then trim
+        return Long.parseLong((s + "000000000").substring(0, 9));
+    }
+
+    private String prepareTime(String s, int baseIndex) {
+        if (s.contains(".")) {
+            int i = s.indexOf(".") + 1;
+            
+            // verify that the first character after the dot is a digit
+            if (Character.isDigit(s.charAt(i))) {
+                i++;
+            } else {
+                throw new CalendricalParseException("Period could not be parsed, invalid decimal number: " +
+                        text, text, baseIndex + index);
+            }
+            
+            // verify that only digits follow the decimal point followed by an S
+            while (i < s.length()) {
+                // || !Character.isDigit(s.charAt(i))
+                char c = s.charAt(i);
+                if (Character.isDigit(c) || c == 'S') {
+                    i++;
+                } else {
+                    throw new CalendricalParseException("Period could not be parsed, invalid decimal number: " +
+                            text, text, baseIndex + index);
+                }
+            }
+            s = s.replace('S', 'N').replace('.', 'S');
+            if (s.contains("-0S")) {
+                negativeSecs = true;
+                s = s.replace("-0S", "0S");
+            }
+        }
+        return s;
+    }
+
+    private int parseInt(String s, int baseIndex) {
+        try {
+            int value = Integer.parseInt(s);
+            if (s.charAt(0) == '-' && value == 0) {
+                throw new CalendricalParseException("Period could not be parsed, invalid number '" +
+                        s + "': " + text, text, baseIndex + index - s.length());
+            }
+            return value;
+        } catch (NumberFormatException ex) {
+            throw new CalendricalParseException("Period could not be parsed, invalid number '" +
+                    s + "': " + text, text, baseIndex + index - s.length());
+        }
+    }
+
+    private String parseNumber(String s) {
+        int start = index;
+        while (index < s.length()) {
+            char c = s.charAt(index);
+            if ((c < '0' || c > '9') && c != '-') {
+                break;
+            }
+            index++;
+        }
+        return s.substring(start, index);
+    }
+
+    private void validateCharactersAndOrdering(String s, CharSequence text) {
+        char[] chars = s.toCharArray();
+        int tokenPos = 0;
+        boolean lastLetter = false;
+        for (int i = 0; i < chars.length; i++) {
+            if (tokenPos >= TOKEN_SEQUENCE.length()) {
+                throw new CalendricalParseException("Period could not be parsed, characters after last 'S': " + text, text, i);
+            }
+            char c = chars[i];
+            if ((c < '0' || c > '9') && c != '-' && c != '.') {
+                tokenPos = TOKEN_SEQUENCE.indexOf(c, tokenPos);
+                if (tokenPos < 0) {
+                    throw new CalendricalParseException("Period could not be parsed, invalid character '" + c + "': " + text, text, i);
+                }
+                tokenPos++;
+                lastLetter = true;
+            } else {
+                lastLetter = false;
+            }
+        }
+        if (lastLetter == false) {
+            throw new CalendricalParseException("Period could not be parsed, invalid last character: " + text, text, s.length() - 1);
+        }
+    }
+
+    private LocalPeriod toPeriod() {
+        return LocalPeriod.of(years, months, days, hours, minutes, seconds, negativeSecs || seconds < 0 ? -nanos : nanos);
+    }
+
+}

--- a/src/test/java/javax/time/TestLocalPeriod.java
+++ b/src/test/java/javax/time/TestLocalPeriod.java
@@ -1,0 +1,1646 @@
+/*
+ * Copyright (c) 2008-2011, Stephen Colebourne & Michael Nascimento Santos
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of JSR-310 nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package javax.time;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.concurrent.TimeUnit;
+
+import javax.time.calendrical.LocalPeriodUnit;
+
+import javax.time.calendrical.PeriodUnit;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Test LocalPeriod.
+ *
+ * @author Michael Nascimento Santos
+ * @author Stephen Colebourne
+ */
+@Test
+public class TestLocalPeriod {
+
+    private static final PeriodUnit MILLENNIA = LocalPeriodUnit.MILLENNIA;
+    private static final PeriodUnit CENTURIES = LocalPeriodUnit.CENTURIES;
+    private static final PeriodUnit DECADES = LocalPeriodUnit.DECADES;
+    private static final PeriodUnit YEARS = LocalPeriodUnit.YEARS;
+    private static final PeriodUnit WEEK_BASED_YEARS = LocalPeriodUnit.WEEK_BASED_YEARS;
+    private static final PeriodUnit QUARTER_YEARS = LocalPeriodUnit.QUARTER_YEARS;
+    private static final PeriodUnit HALF_YEARS = LocalPeriodUnit.HALF_YEARS;
+    private static final PeriodUnit MONTHS = LocalPeriodUnit.MONTHS;
+    private static final PeriodUnit WEEKS = LocalPeriodUnit.WEEKS;
+    private static final PeriodUnit DAYS = LocalPeriodUnit.DAYS;
+    private static final PeriodUnit HALF_DAYS = LocalPeriodUnit.HALF_DAYS;
+    private static final PeriodUnit HOURS = LocalPeriodUnit.HOURS;
+    private static final PeriodUnit MINUTES = LocalPeriodUnit.MINUTES;
+    private static final PeriodUnit SECONDS = LocalPeriodUnit.SECONDS;
+    private static final PeriodUnit MILLIS = LocalPeriodUnit.MILLIS;
+    private static final PeriodUnit MICROS = LocalPeriodUnit.MICROS;
+    private static final PeriodUnit NANOS = LocalPeriodUnit.NANOS;
+
+    private static final BigInteger MAX_BINT = BigInteger.valueOf(Integer.MAX_VALUE);
+    private static final BigInteger BINT_24 = BigInteger.valueOf(24);
+    private static final BigInteger BINT_60 = BigInteger.valueOf(60);
+    private static final BigInteger BINT_1BN = BigInteger.valueOf(1000000000L);
+
+    //-----------------------------------------------------------------------
+    // basics
+    //-----------------------------------------------------------------------
+    public void test_interfaces() {
+        assertTrue(Serializable.class.isAssignableFrom(LocalPeriod.class));
+    }
+
+    @DataProvider(name="serialization")
+    Object[][] data_serialization() {
+        return new Object[][] {
+            {LocalPeriod.ZERO},
+            {LocalPeriod.of(0, DAYS)},
+            {LocalPeriod.of(1, DAYS)},
+            {LocalPeriod.of(1, 2, 3, 4, 5, 6)},
+        };
+    }
+
+    @Test(dataProvider="serialization")
+    public void test_serialization(LocalPeriod period) throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(period);
+        oos.close();
+        
+        ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(
+                baos.toByteArray()));
+        if (period.isZero()) {
+            assertSame(ois.readObject(), period);
+        } else {
+            assertEquals(ois.readObject(), period);
+        }
+    }
+
+    public void test_immutable() {
+        Class<LocalPeriod> cls = LocalPeriod.class;
+        assertTrue(Modifier.isPublic(cls.getModifiers()));
+        assertTrue(Modifier.isFinal(cls.getModifiers()));
+        Field[] fields = cls.getDeclaredFields();
+        for (Field field : fields) {
+            if (Modifier.isStatic(field.getModifiers()) == false && !Modifier.isTransient(field.getModifiers())) {
+                assertTrue(Modifier.isPrivate(field.getModifiers()));
+                assertTrue(Modifier.isFinal(field.getModifiers()));
+            }
+        }
+        Constructor<?>[] cons = cls.getDeclaredConstructors();
+        for (Constructor<?> con : cons) {
+            assertTrue(Modifier.isPrivate(con.getModifiers()));
+        }
+    }
+
+    //-----------------------------------------------------------------------
+    // factories
+    //-----------------------------------------------------------------------
+    public void factory_zeroSingleton() {
+        assertSame(LocalPeriod.ZERO, LocalPeriod.ZERO);
+        assertSame(LocalPeriod.of(0, 0, 0, 0, 0, 0), LocalPeriod.ZERO);
+        assertSame(LocalPeriod.of(0, 0, 0, 0, 0, 0, 0), LocalPeriod.ZERO);
+        assertSame(LocalPeriod.ofDate(0, 0, 0), LocalPeriod.ZERO);
+        assertSame(LocalPeriod.ofTime(0, 0, 0), LocalPeriod.ZERO);
+        assertSame(LocalPeriod.ofTime(0, 0, 0, 0), LocalPeriod.ZERO);
+        assertSame(LocalPeriod.of(0, YEARS), LocalPeriod.ZERO);
+        assertSame(LocalPeriod.of(0, MONTHS), LocalPeriod.ZERO);
+        assertSame(LocalPeriod.of(0, DAYS), LocalPeriod.ZERO);
+        assertSame(LocalPeriod.of(0, HOURS), LocalPeriod.ZERO);
+        assertSame(LocalPeriod.of(0, MINUTES), LocalPeriod.ZERO);
+        assertSame(LocalPeriod.of(0, SECONDS), LocalPeriod.ZERO);
+        assertSame(LocalPeriod.of(0, NANOS), LocalPeriod.ZERO);
+    }
+
+    //-----------------------------------------------------------------------
+    // of(PeriodProvider)
+    //-----------------------------------------------------------------------
+    public void factory_of_ints() {
+        assertPeriod(LocalPeriod.of(1, 2, 3, 4, 5, 6), 1, 2, 3, 4, 5, 6, 0);
+        assertPeriod(LocalPeriod.of(0, 2, 3, 4, 5, 6), 0, 2, 3, 4, 5, 6, 0);
+        assertPeriod(LocalPeriod.of(1, 0, 0, 0, 0, 0), 1, 0, 0, 0, 0, 0, 0);
+        assertPeriod(LocalPeriod.of(0, 0, 0, 0, 0, 0), 0, 0, 0, 0, 0, 0, 0);
+        assertPeriod(LocalPeriod.of(-1, -2, -3, -4, -5, -6), -1, -2, -3, -4, -5, -6, 0);
+    }
+
+    //-----------------------------------------------------------------------
+    // ofDate
+    //-----------------------------------------------------------------------
+    public void factory_ofDate_ints() {
+        assertPeriod(LocalPeriod.ofDate(1, 2, 3), 1, 2, 3, 0, 0, 0, 0);
+        assertPeriod(LocalPeriod.ofDate(0, 2, 3), 0, 2, 3, 0, 0, 0, 0);
+        assertPeriod(LocalPeriod.ofDate(1, 0, 0), 1, 0, 0, 0, 0, 0, 0);
+        assertPeriod(LocalPeriod.ofDate(0, 0, 0), 0, 0, 0, 0, 0, 0, 0);
+        assertPeriod(LocalPeriod.ofDate(-1, -2, -3), -1, -2, -3, 0, 0, 0, 0);
+    }
+
+    //-----------------------------------------------------------------------
+    // ofTime
+    //-----------------------------------------------------------------------
+    public void factory_ofTime_3ints() {
+        assertPeriod(LocalPeriod.ofTime(1, 2, 3), 0, 0, 0, 1, 2, 3, 0);
+        assertPeriod(LocalPeriod.ofTime(0, 2, 3), 0, 0, 0, 0, 2, 3, 0);
+        assertPeriod(LocalPeriod.ofTime(1, 0, 0), 0, 0, 0, 1, 0, 0, 0);
+        assertPeriod(LocalPeriod.ofTime(0, 0, 0), 0, 0, 0, 0, 0, 0, 0);
+        assertPeriod(LocalPeriod.ofTime(-1, -2, -3), 0, 0, 0, -1, -2, -3, 0);
+    }
+
+    public void factory_ofTime_4ints() {
+        assertPeriod(LocalPeriod.ofTime(1, 2, 3, 4), 0, 0, 0, 1, 2, 3, 4);
+        assertPeriod(LocalPeriod.ofTime(0, 2, 3, 4), 0, 0, 0, 0, 2, 3, 4);
+        assertPeriod(LocalPeriod.ofTime(1, 0, 0, 0), 0, 0, 0, 1, 0, 0, 0);
+        assertPeriod(LocalPeriod.ofTime(0, 0, 0, 0), 0, 0, 0, 0, 0, 0, 0);
+        assertPeriod(LocalPeriod.ofTime(-1, -2, -3, -4), 0, 0, 0, -1, -2, -3, -4);
+    }
+
+    //-----------------------------------------------------------------------
+    // of one field
+    //-----------------------------------------------------------------------
+    public void test_factory_of_intPeriodUnit() {
+        assertEquals(LocalPeriod.of(1, YEARS), LocalPeriod.of(1, YEARS));
+        assertEquals(LocalPeriod.of(2, WEEK_BASED_YEARS), LocalPeriod.of(2, YEARS));
+        assertEquals(LocalPeriod.of(2, MONTHS), LocalPeriod.of(2, MONTHS));
+        assertEquals(LocalPeriod.of(3, DAYS), LocalPeriod.of(3, DAYS));
+        assertEquals(LocalPeriod.of(1, HALF_DAYS), LocalPeriod.of(12, HOURS));
+        assertEquals(LocalPeriod.of(Integer.MAX_VALUE, HOURS), LocalPeriod.of(Integer.MAX_VALUE, HOURS));
+        assertEquals(LocalPeriod.of(-1, MINUTES), LocalPeriod.of(-1, MINUTES));
+        assertEquals(LocalPeriod.of(-2, SECONDS), LocalPeriod.of(-2, SECONDS));
+        assertEquals(LocalPeriod.of(Integer.MIN_VALUE, NANOS), LocalPeriod.of(Integer.MIN_VALUE, NANOS));
+    }
+
+    public void test_factory_of_intPeriodUnit_convert() {
+        assertEquals(LocalPeriod.of(2, MILLIS), LocalPeriod.of(2000000, NANOS));
+        assertEquals(LocalPeriod.of(2, MICROS), LocalPeriod.of(2000, NANOS));
+        assertEquals(LocalPeriod.of(2, WEEKS), LocalPeriod.of(14, DAYS));
+        assertEquals(LocalPeriod.of(2, QUARTER_YEARS), LocalPeriod.of(6, MONTHS));
+        assertEquals(LocalPeriod.of(1, HALF_YEARS), LocalPeriod.of(6 , MONTHS));
+        assertEquals(LocalPeriod.of(2, DECADES), LocalPeriod.of(20, YEARS));
+        assertEquals(LocalPeriod.of(2, CENTURIES), LocalPeriod.of(200, YEARS));
+        assertEquals(LocalPeriod.of(2, MILLENNIA), LocalPeriod.of(2000, YEARS));
+    }
+
+    @Test(expectedExceptions=NullPointerException.class)
+    public void test_factory_of_intPeriodUnit_null() {
+        LocalPeriod.of(1, null);
+    }
+
+    //-----------------------------------------------------------------------
+    public void factory_years() {
+        assertPeriod(LocalPeriod.of(1, YEARS), 1, 0, 0, 0, 0, 0, 0);
+        assertPeriod(LocalPeriod.of(0, YEARS), 0, 0, 0, 0, 0, 0, 0);
+        assertPeriod(LocalPeriod.of(-1, YEARS), -1, 0, 0, 0, 0, 0, 0);
+        assertPeriod(LocalPeriod.of(Integer.MAX_VALUE, YEARS), Integer.MAX_VALUE, 0, 0, 0, 0, 0, 0);
+        assertPeriod(LocalPeriod.of(Integer.MIN_VALUE, YEARS), Integer.MIN_VALUE, 0, 0, 0, 0, 0, 0);
+    }
+
+    public void factory_months() {
+        assertPeriod(LocalPeriod.of(1, MONTHS), 0, 1, 0, 0, 0, 0, 0);
+        assertPeriod(LocalPeriod.of(0, MONTHS), 0, 0, 0, 0, 0, 0, 0);
+        assertPeriod(LocalPeriod.of(-1, MONTHS), 0, -1, 0, 0, 0, 0, 0);
+        assertPeriod(LocalPeriod.of(Integer.MAX_VALUE, MONTHS), 0, Integer.MAX_VALUE, 0, 0, 0, 0, 0);
+        assertPeriod(LocalPeriod.of(Integer.MIN_VALUE, MONTHS), 0, Integer.MIN_VALUE, 0, 0, 0, 0, 0);
+    }
+
+    public void factory_days() {
+        assertPeriod(LocalPeriod.of(1, DAYS), 0, 0, 1, 0, 0, 0, 0);
+        assertPeriod(LocalPeriod.of(0, DAYS), 0, 0, 0, 0, 0, 0, 0);
+        assertPeriod(LocalPeriod.of(-1, DAYS), 0, 0, -1, 0, 0, 0, 0);
+        assertPeriod(LocalPeriod.of(Integer.MAX_VALUE, DAYS), 0, 0, Integer.MAX_VALUE, 0, 0, 0, 0);
+        assertPeriod(LocalPeriod.of(Integer.MIN_VALUE, DAYS), 0, 0, Integer.MIN_VALUE, 0, 0, 0, 0);
+    }
+
+    public void factory_hours() {
+        assertPeriod(LocalPeriod.of(1, HOURS), 0, 0, 0, 1, 0, 0, 0);
+        assertPeriod(LocalPeriod.of(0, HOURS), 0, 0, 0, 0, 0, 0, 0);
+        assertPeriod(LocalPeriod.of(-1, HOURS), 0, 0, 0, -1, 0, 0, 0);
+        assertPeriod(LocalPeriod.of(Integer.MAX_VALUE, HOURS), 0, 0, 0, Integer.MAX_VALUE, 0, 0, 0);
+        assertPeriod(LocalPeriod.of(Integer.MIN_VALUE, HOURS), 0, 0, 0, Integer.MIN_VALUE, 0, 0, 0);
+    }
+
+    public void factory_minutes() {
+        assertPeriod(LocalPeriod.of(1, MINUTES), 0, 0, 0, 0, 1, 0, 0);
+        assertPeriod(LocalPeriod.of(0, MINUTES), 0, 0, 0, 0, 0, 0, 0);
+        assertPeriod(LocalPeriod.of(-1, MINUTES), 0, 0, 0, 0, -1, 0, 0);
+        assertPeriod(LocalPeriod.of(Integer.MAX_VALUE, MINUTES), 0, 0, 0, 0, Integer.MAX_VALUE, 0, 0);
+        assertPeriod(LocalPeriod.of(Integer.MIN_VALUE, MINUTES), 0, 0, 0, 0, Integer.MIN_VALUE, 0, 0);
+    }
+
+    public void factory_seconds() {
+        assertPeriod(LocalPeriod.of(1, SECONDS), 0, 0, 0, 0, 0, 1, 0);
+        assertPeriod(LocalPeriod.of(0, SECONDS), 0, 0, 0, 0, 0, 0, 0);
+        assertPeriod(LocalPeriod.of(-1, SECONDS), 0, 0, 0, 0, 0, -1, 0);
+        assertPeriod(LocalPeriod.of(Integer.MAX_VALUE, SECONDS), 0, 0, 0, 0, 0, Integer.MAX_VALUE, 0);
+        assertPeriod(LocalPeriod.of(Integer.MIN_VALUE, SECONDS), 0, 0, 0, 0, 0, Integer.MIN_VALUE, 0);
+    }
+
+    public void factory_nanos() {
+        assertPeriod(LocalPeriod.of(1, NANOS), 0, 0, 0, 0, 0, 0, 1);
+        assertPeriod(LocalPeriod.of(0, NANOS), 0, 0, 0, 0, 0, 0, 0);
+        assertPeriod(LocalPeriod.of(-1, NANOS), 0, 0, 0, 0, 0, 0, -1);
+        assertPeriod(LocalPeriod.of(Long.MAX_VALUE, NANOS), 0, 0, 0, 0, 0, 0, Long.MAX_VALUE);
+        assertPeriod(LocalPeriod.of(Long.MIN_VALUE, NANOS), 0, 0, 0, 0, 0, 0, Long.MIN_VALUE);
+    }
+
+    //-----------------------------------------------------------------------
+    // of(Period)
+    //-----------------------------------------------------------------------
+    @DataProvider(name="PeriodData")
+    Object[][] data_ofPeriod() {
+        return new Object[][] {
+            {Period.ZERO_DAYS, LocalPeriod.ZERO},
+            {Period.ZERO_SECONDS, LocalPeriod.ZERO},
+            {Period.of(0, DAYS), LocalPeriod.ZERO},
+            {Period.of(1, MILLENNIA), LocalPeriod.ofDate(1000, 0, 0)},
+            {Period.of(1, CENTURIES), LocalPeriod.ofDate(100, 0, 0)},
+            {Period.of(1, DECADES), LocalPeriod.ofDate(10, 0, 0)},
+            {Period.of(1, WEEK_BASED_YEARS), LocalPeriod.ofDate(1, 0, 0)},
+            {Period.of(1, YEARS), LocalPeriod.ofDate(1, 0, 0)},
+            {Period.of(1, HALF_YEARS), LocalPeriod.ofDate(0, 6, 0)},
+            {Period.of(1, QUARTER_YEARS), LocalPeriod.ofDate(0, 3, 0)},
+            {Period.of(1, MONTHS), LocalPeriod.ofDate(0, 1, 0)},
+            {Period.of(1, DAYS), LocalPeriod.ofDate(0, 0, 1)},
+            {Period.of(1, HOURS), LocalPeriod.ofTime(1, 0, 0)},
+            {Period.of(1, MINUTES), LocalPeriod.ofTime(0, 1, 0)},
+            {Period.of(1, SECONDS), LocalPeriod.ofTime(0, 0, 1)},
+            {Period.of(1, NANOS), LocalPeriod.ofTime(0, 0, 0, 1)},
+        };
+    }
+
+    @Test(dataProvider="PeriodData")
+    public void factory_ofPeriod(Period period, LocalPeriod localPeriod) {
+        LocalPeriod test = LocalPeriod.of(period);
+        assertEquals(localPeriod, test);
+
+    }
+
+
+    //-----------------------------------------------------------------------
+    // of(Duration)
+    //-----------------------------------------------------------------------
+    public void factory_duration() {
+        assertPeriod(LocalPeriod.of(Duration.ofSeconds(2, 3)), 0, 0, 0, 0, 0, 2, 3);
+        assertPeriod(LocalPeriod.of(Duration.ofSeconds(59, 3)), 0, 0, 0, 0, 0, 59, 3);
+        assertPeriod(LocalPeriod.of(Duration.ofSeconds(60, 3)), 0, 0, 0, 0, 1, 0, 3);
+        assertPeriod(LocalPeriod.of(Duration.ofSeconds(61, 3)), 0, 0, 0, 0, 1, 1, 3);
+        assertPeriod(LocalPeriod.of(Duration.ofSeconds(3599, 3)), 0, 0, 0, 0, 59, 59, 3);
+        assertPeriod(LocalPeriod.of(Duration.ofSeconds(3600, 3)), 0, 0, 0, 1, 0, 0, 3);
+    }
+
+    public void factory_duration_negative() {
+        assertPeriod(LocalPeriod.of(Duration.ofSeconds(-2, 3)), 0, 0, 0, 0, 0, -2, 3);
+        assertPeriod(LocalPeriod.of(Duration.ofSeconds(-59, 3)), 0, 0, 0, 0, 0, -59, 3);
+        assertPeriod(LocalPeriod.of(Duration.ofSeconds(-60, 3)), 0, 0, 0, 0, -1, 0, 3);
+        
+        assertPeriod(LocalPeriod.of(Duration.ofSeconds(2, -3)), 0, 0, 0, 0, 0, 1, 999999997);
+    }
+
+    public void factory_duration_big() {
+        Duration dur = Duration.ofSeconds(2, Long.MAX_VALUE);
+        long secs = Long.MAX_VALUE / 1000000000 + 2;
+        long nanos = Long.MAX_VALUE % 1000000000;
+        assertPeriod(LocalPeriod.of(dur), 0, 0, 0, (int) (secs / 3600), (int) ((secs % 3600) / 60), (int) (secs % 60), nanos);
+    }
+
+    @Test(expectedExceptions=NullPointerException.class)
+    public void factory_duration_null() {
+        LocalPeriod.of((Duration) null);
+    }
+
+    //-----------------------------------------------------------------------
+    // between
+    //-----------------------------------------------------------------------
+    @DataProvider(name="Between")
+    Object[][] data_between() {
+        return new Object[][] {
+            {2010, 1, 1, 2010, 1, 1, 0, 0, 0},
+            {2010, 1, 1, 2010, 1, 2, 0, 0, 1},
+            {2010, 1, 1, 2010, 1, 31, 0, 0, 30},
+            {2010, 1, 1, 2010, 2, 1, 0, 1, 0},
+            {2010, 1, 1, 2010, 2, 28, 0, 1, 27},
+            {2010, 1, 1, 2010, 3, 1, 0, 2, 0},
+            {2010, 1, 1, 2010, 12, 31, 0, 11, 30},
+            {2010, 1, 1, 2011, 1, 1, 1, 0, 0},
+            {2010, 1, 1, 2011, 12, 31, 1, 11, 30},
+            {2010, 1, 1, 2012, 1, 1, 2, 0, 0},
+            
+            {2010, 1, 10, 2010, 1, 1, 0, 0, -9},
+            {2010, 1, 10, 2010, 1, 2, 0, 0, -8},
+            {2010, 1, 10, 2010, 1, 9, 0, 0, -1},
+            {2010, 1, 10, 2010, 1, 10, 0, 0, 0},
+            {2010, 1, 10, 2010, 1, 11, 0, 0, 1},
+            {2010, 1, 10, 2010, 1, 31, 0, 0, 21},
+            {2010, 1, 10, 2010, 2, 1, 0, 0, 22},
+            {2010, 1, 10, 2010, 2, 9, 0, 0, 30},
+            {2010, 1, 10, 2010, 2, 10, 0, 1, 0},
+            {2010, 1, 10, 2010, 2, 28, 0, 1, 18},
+            {2010, 1, 10, 2010, 3, 1, 0, 1, 19},
+            {2010, 1, 10, 2010, 3, 9, 0, 1, 27},
+            {2010, 1, 10, 2010, 3, 10, 0, 2, 0},
+            {2010, 1, 10, 2010, 12, 31, 0, 11, 21},
+            {2010, 1, 10, 2011, 1, 1, 0, 11, 22},
+            {2010, 1, 10, 2011, 1, 9, 0, 11, 30},
+            {2010, 1, 10, 2011, 1, 10, 1, 0, 0},
+            
+            {2010, 3, 30, 2011, 5, 1, 1, 1, 1},
+            {2010, 4, 30, 2011, 5, 1, 1, 0, 1},
+            
+            {2010, 2, 28, 2012, 2, 27, 1, 11, 30},
+            {2010, 2, 28, 2012, 2, 28, 2, 0, 0},
+            {2010, 2, 28, 2012, 2, 29, 2, 0, 1},
+            
+            {2012, 2, 28, 2014, 2, 27, 1, 11, 30},
+            {2012, 2, 28, 2014, 2, 28, 2, 0, 0},
+            {2012, 2, 28, 2014, 3, 1, 2, 0, 1},
+            
+            {2012, 2, 29, 2014, 2, 28, 1, 11, 30},
+            {2012, 2, 29, 2014, 3, 1, 2, 0, 1},
+            {2012, 2, 29, 2014, 3, 2, 2, 0, 2},
+            
+            {2012, 2, 29, 2016, 2, 28, 3, 11, 30},
+            {2012, 2, 29, 2016, 2, 29, 4, 0, 0},
+            {2012, 2, 29, 2016, 3, 1, 4, 0, 1},
+            
+            {2010, 1, 1, 2009, 12, 31, 0, 0, -1},
+            {2010, 1, 1, 2009, 12, 30, 0, 0, -2},
+            {2010, 1, 1, 2009, 12, 2, 0, 0, -30},
+            {2010, 1, 1, 2009, 12, 1, 0, -1, 0},
+            {2010, 1, 1, 2009, 11, 30, 0, -1, -1},
+            {2010, 1, 1, 2009, 11, 2, 0, -1, -29},
+            {2010, 1, 1, 2009, 11, 1, 0, -2, 0},
+            {2010, 1, 1, 2009, 1, 2, 0, -11, -30},
+            {2010, 1, 1, 2009, 1, 1, -1, 0, 0},
+            
+            {2010, 1, 15, 2010, 1, 15, 0, 0, 0},
+            {2010, 1, 15, 2010, 1, 14, 0, 0, -1},
+            {2010, 1, 15, 2010, 1, 1, 0, 0, -14},
+            {2010, 1, 15, 2009, 12, 31, 0, 0, -15},
+            {2010, 1, 15, 2009, 12, 16, 0, 0, -30},
+            {2010, 1, 15, 2009, 12, 15, 0, -1, 0},
+            {2010, 1, 15, 2009, 12, 14, 0, -1, -1},
+            
+            {2010, 2, 28, 2009, 3, 1, 0, -11, -27},
+            {2010, 2, 28, 2009, 2, 28, -1, 0, 0},
+            {2010, 2, 28, 2009, 2, 27, -1, 0, -1},
+            
+            {2010, 2, 28, 2008, 2, 29, -1, -11, -28},
+            {2010, 2, 28, 2008, 2, 28, -2, 0, 0},
+            {2010, 2, 28, 2008, 2, 27, -2, 0, -1},
+            
+            {2012, 2, 29, 2009, 3, 1, -2, -11, -28},
+            {2012, 2, 29, 2009, 2, 28, -3, 0, -1},
+            {2012, 2, 29, 2009, 2, 27, -3, 0, -2},
+            
+            {2012, 2, 29, 2008, 3, 1, -3, -11, -28},
+            {2012, 2, 29, 2008, 2, 29, -4, 0, 0},
+            {2012, 2, 29, 2008, 2, 28, -4, 0, -1},
+        };
+    }
+
+    @Test(dataProvider="Between")
+    public void factory_between(int y1, int m1, int d1, int y2, int m2, int d2, int ye, int me, int de) {
+        LocalDate start = LocalDate.of(y1, m1, d1);
+        LocalDate end = LocalDate.of(y2, m2, d2);
+        LocalPeriod test = LocalPeriod.between(start, end);
+        assertPeriod(test, ye, me, de, 0, 0, 0, 0);
+        //assertEquals(start.plus(test), end);
+    }
+
+    @Test(expectedExceptions=NullPointerException.class)
+    public void factory_between_nullFirst() {
+        LocalPeriod.between((LocalDate) null, LocalDate.of(2010, 1, 1));
+    }
+
+    @Test(expectedExceptions=NullPointerException.class)
+    public void factory_between_nullSecond() {
+        LocalPeriod.between(LocalDate.of(2010, 1, 1), (LocalDate) null);
+    }
+
+    //-----------------------------------------------------------------------
+    // parse()
+    //-----------------------------------------------------------------------
+    @Test(dataProvider="toStringAndParse")
+    public void test_parse(LocalPeriod test, String expected) {
+        if (Math.signum(test.getSeconds()) == Math.signum(test.getNanos())) {
+            assertEquals(test, LocalPeriod.parse(expected));
+        }
+    }
+
+    @Test(expectedExceptions=NullPointerException.class)
+    public void test_parse_nullText() {
+        LocalPeriod.parse((String) null);
+    }
+
+    //-----------------------------------------------------------------------
+    // isZero()
+    //-----------------------------------------------------------------------
+    public void test_isZero() {
+        assertEquals(LocalPeriod.of(1, 2, 3, 4, 5, 6, 7).isZero(), false);
+        assertEquals(LocalPeriod.of(1, 2, 3, 0, 0, 0, 0).isZero(), false);
+        assertEquals(LocalPeriod.of(0, 0, 0, 4, 5, 6, 7).isZero(), false);
+        assertEquals(LocalPeriod.of(1, 0, 0, 0, 0, 0, 0).isZero(), false);
+        assertEquals(LocalPeriod.of(0, 2, 0, 0, 0, 0, 0).isZero(), false);
+        assertEquals(LocalPeriod.of(0, 0, 3, 0, 0, 0, 0).isZero(), false);
+        assertEquals(LocalPeriod.of(0, 0, 0, 4, 0, 0, 0).isZero(), false);
+        assertEquals(LocalPeriod.of(0, 0, 0, 0, 5, 0, 0).isZero(), false);
+        assertEquals(LocalPeriod.of(0, 0, 0, 0, 0, 6, 0).isZero(), false);
+        assertEquals(LocalPeriod.of(0, 0, 0, 0, 0, 0, 7).isZero(), false);
+        assertEquals(LocalPeriod.of(0, 0, 0, 0, 0, 0).isZero(), true);
+    }
+
+    //-----------------------------------------------------------------------
+    // isPositive()
+    //-----------------------------------------------------------------------
+    public void test_isPositive() {
+        assertEquals(LocalPeriod.of(1, 2, 3, 4, 5, 6, 7).isPositive(), true);
+        assertEquals(LocalPeriod.of(1, 2, 3, 0, 0, 0, 0).isPositive(), true);
+        assertEquals(LocalPeriod.of(0, 0, 0, 4, 5, 6, 7).isPositive(), true);
+        assertEquals(LocalPeriod.of(1, 0, 0, 0, 0, 0, 0).isPositive(), true);
+        assertEquals(LocalPeriod.of(0, 2, 0, 0, 0, 0, 0).isPositive(), true);
+        assertEquals(LocalPeriod.of(0, 0, 3, 0, 0, 0, 0).isPositive(), true);
+        assertEquals(LocalPeriod.of(0, 0, 0, 4, 0, 0, 0).isPositive(), true);
+        assertEquals(LocalPeriod.of(0, 0, 0, 0, 5, 0, 0).isPositive(), true);
+        assertEquals(LocalPeriod.of(0, 0, 0, 0, 0, 6, 0).isPositive(), true);
+        assertEquals(LocalPeriod.of(0, 0, 0, 0, 0, 0, 7).isPositive(), true);
+        assertEquals(LocalPeriod.of(-1, -2, -3, -4, -5, -6, -7).isPositive(), false);
+        assertEquals(LocalPeriod.of(-1, -2, 3, 4, -5, -6, -7).isPositive(), false);
+        assertEquals(LocalPeriod.of(-1, 0, 0, 0, 0, 0, 0).isPositive(), false);
+        assertEquals(LocalPeriod.of(0, -2, 0, 0, 0, 0, 0).isPositive(), false);
+        assertEquals(LocalPeriod.of(0, 0, -3, 0, 0, 0, 0).isPositive(), false);
+        assertEquals(LocalPeriod.of(0, 0, 0, -4, 0, 0, 0).isPositive(), false);
+        assertEquals(LocalPeriod.of(0, 0, 0, 0, -5, 0, 0).isPositive(), false);
+        assertEquals(LocalPeriod.of(0, 0, 0, 0, 0, -6, 0).isPositive(), false);
+        assertEquals(LocalPeriod.of(0, 0, 0, 0, 0, 0, -7).isPositive(), false);
+        assertEquals(LocalPeriod.of(0, 0, 0, 0, 0, 0).isPositive(), false);
+    }
+
+    //-----------------------------------------------------------------------
+    // isPositiveOrZero()
+    //-----------------------------------------------------------------------
+    public void test_isPositiveOrZero() {
+        assertEquals(LocalPeriod.of(1, 2, 3, 4, 5, 6, 7).isPositiveOrZero(), true);
+        assertEquals(LocalPeriod.of(1, 2, 3, 0, 0, 0, 0).isPositiveOrZero(), true);
+        assertEquals(LocalPeriod.of(0, 0, 0, 4, 5, 6, 7).isPositiveOrZero(), true);
+        assertEquals(LocalPeriod.of(1, 0, 0, 0, 0, 0, 0).isPositiveOrZero(), true);
+        assertEquals(LocalPeriod.of(0, 2, 0, 0, 0, 0, 0).isPositiveOrZero(), true);
+        assertEquals(LocalPeriod.of(0, 0, 3, 0, 0, 0, 0).isPositiveOrZero(), true);
+        assertEquals(LocalPeriod.of(0, 0, 0, 4, 0, 0, 0).isPositiveOrZero(), true);
+        assertEquals(LocalPeriod.of(0, 0, 0, 0, 5, 0, 0).isPositiveOrZero(), true);
+        assertEquals(LocalPeriod.of(0, 0, 0, 0, 0, 6, 0).isPositiveOrZero(), true);
+        assertEquals(LocalPeriod.of(0, 0, 0, 0, 0, 0, 7).isPositiveOrZero(), true);
+        assertEquals(LocalPeriod.of(-1, -2, -3, -4, -5, -6, -7).isPositiveOrZero(), false);
+        assertEquals(LocalPeriod.of(-1, -2, 3, 4, -5, -6, -7).isPositiveOrZero(), false);
+        assertEquals(LocalPeriod.of(-1, 0, 0, 0, 0, 0, 0).isPositiveOrZero(), false);
+        assertEquals(LocalPeriod.of(0, -2, 0, 0, 0, 0, 0).isPositiveOrZero(), false);
+        assertEquals(LocalPeriod.of(0, 0, -3, 0, 0, 0, 0).isPositiveOrZero(), false);
+        assertEquals(LocalPeriod.of(0, 0, 0, -4, 0, 0, 0).isPositiveOrZero(), false);
+        assertEquals(LocalPeriod.of(0, 0, 0, 0, -5, 0, 0).isPositiveOrZero(), false);
+        assertEquals(LocalPeriod.of(0, 0, 0, 0, 0, -6, 0).isPositiveOrZero(), false);
+        assertEquals(LocalPeriod.of(0, 0, 0, 0, 0, 0, -7).isPositiveOrZero(), false);
+        assertEquals(LocalPeriod.of(0, 0, 0, 0, 0, 0).isPositiveOrZero(), true);
+    }
+
+    //-----------------------------------------------------------------------
+    // getNanosInt()
+    //-----------------------------------------------------------------------
+    public void test_getNanosInt() {
+        LocalPeriod test = LocalPeriod.of(Integer.MAX_VALUE, NANOS);
+        assertEquals(test.getNanosInt(), Integer.MAX_VALUE);
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_getNanosInt_tooBig() {
+        LocalPeriod test = LocalPeriod.of(Integer.MAX_VALUE + 1L, NANOS);
+        test.getNanosInt();
+    }
+
+    //-----------------------------------------------------------------------
+    // withYears()
+    //-----------------------------------------------------------------------
+    public void test_withYears() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertPeriod(test.withYears(10), 10, 2, 3, 4, 5, 6, 7);
+    }
+
+    public void test_withYears_noChange() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertSame(test.withYears(1), test);
+    }
+
+    public void test_withYears_toZero() {
+        LocalPeriod test = LocalPeriod.of(1, YEARS);
+        assertSame(test.withYears(0), LocalPeriod.ZERO);
+    }
+
+    //-----------------------------------------------------------------------
+    // withMonths()
+    //-----------------------------------------------------------------------
+    public void test_withMonths() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertPeriod(test.withMonths(10), 1, 10, 3, 4, 5, 6, 7);
+    }
+
+    public void test_withMonths_noChange() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertSame(test.withMonths(2), test);
+    }
+
+    public void test_withMonths_toZero() {
+        LocalPeriod test = LocalPeriod.of(1, MONTHS);
+        assertSame(test.withMonths(0), LocalPeriod.ZERO);
+    }
+
+    //-----------------------------------------------------------------------
+    // withDays()
+    //-----------------------------------------------------------------------
+    public void test_withDays() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertPeriod(test.withDays(10), 1, 2, 10, 4, 5, 6, 7);
+    }
+
+    public void test_withDays_noChange() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertSame(test.withDays(3), test);
+    }
+
+    public void test_withDays_toZero() {
+        LocalPeriod test = LocalPeriod.of(1, DAYS);
+        assertSame(test.withDays(0), LocalPeriod.ZERO);
+    }
+
+    //-----------------------------------------------------------------------
+    // withHours()
+    //-----------------------------------------------------------------------
+    public void test_withHours() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertPeriod(test.withHours(10), 1, 2, 3, 10, 5, 6, 7);
+    }
+
+    public void test_withHours_noChange() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertSame(test.withHours(4), test);
+    }
+
+    public void test_withHours_toZero() {
+        LocalPeriod test = LocalPeriod.of(1, HOURS);
+        assertSame(test.withHours(0), LocalPeriod.ZERO);
+    }
+
+    //-----------------------------------------------------------------------
+    // withMinutes()
+    //-----------------------------------------------------------------------
+    public void test_withMinutes() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertPeriod(test.withMinutes(10), 1, 2, 3, 4, 10, 6, 7);
+    }
+
+    public void test_withMinutes_noChange() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertSame(test.withMinutes(5), test);
+    }
+
+    public void test_withMinutes_toZero() {
+        LocalPeriod test = LocalPeriod.of(1, MINUTES);
+        assertSame(test.withMinutes(0), LocalPeriod.ZERO);
+    }
+
+    //-----------------------------------------------------------------------
+    // withSeconds()
+    //-----------------------------------------------------------------------
+    public void test_withSeconds() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertPeriod(test.withSeconds(10), 1, 2, 3, 4, 5, 10, 7);
+    }
+
+    public void test_withSeconds_noChange() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertSame(test.withSeconds(6), test);
+    }
+
+    public void test_withSeconds_toZero() {
+        LocalPeriod test = LocalPeriod.of(1, SECONDS);
+        assertSame(test.withSeconds(0), LocalPeriod.ZERO);
+    }
+
+    //-----------------------------------------------------------------------
+    // withNanos()
+    //-----------------------------------------------------------------------
+    public void test_withNanos() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertPeriod(test.withNanos(10), 1, 2, 3, 4, 5, 6, 10);
+    }
+
+    public void test_withNanos_noChange() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertSame(test.withNanos(7), test);
+    }
+
+    public void test_withNanos_toZero() {
+        LocalPeriod test = LocalPeriod.of(1, NANOS);
+        assertSame(test.withNanos(0), LocalPeriod.ZERO);
+    }
+
+
+
+    //-----------------------------------------------------------------------
+    // plusYears()
+    //-----------------------------------------------------------------------
+    public void test_plusYears() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertPeriod(test.plus(10, YEARS), 11, 2, 3, 4, 5, 6, 7);
+        assertPeriod(test.plus(LocalPeriod.of(10, YEARS)), 11, 2, 3, 4, 5, 6, 7);
+    }
+
+    public void test_plusYears_noChange() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertSame(test.plus(0, YEARS), test);
+        assertPeriod(test.plus(LocalPeriod.of(0, YEARS)), 1, 2, 3, 4, 5, 6, 7);
+    }
+
+    public void test_plusYears_toZero() {
+        LocalPeriod test = LocalPeriod.of(-1, YEARS);
+        assertSame(test.plus(1, YEARS), LocalPeriod.ZERO);
+        assertSame(test.plus(LocalPeriod.of(1, YEARS)), LocalPeriod.ZERO);
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_plusYears_overflowTooBig() {
+        LocalPeriod test = LocalPeriod.of(Integer.MAX_VALUE, YEARS);
+        test.plus(1, YEARS);
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_plusYears_overflowTooSmall() {
+        LocalPeriod test = LocalPeriod.of(Integer.MIN_VALUE, YEARS);
+        test.plus(-1, YEARS);
+    }
+
+    //-----------------------------------------------------------------------
+    // plusMonths()
+    //-----------------------------------------------------------------------
+    public void test_plusMonths() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertPeriod(test.plus(10, MONTHS), 1, 12, 3, 4, 5, 6, 7);
+        assertPeriod(test.plus(LocalPeriod.of(10, MONTHS)), 1, 12, 3, 4, 5, 6, 7);
+        assertPeriod(test.plus(LocalPeriod.of(Period.of(10, MONTHS))), 1, 12, 3, 4, 5, 6, 7);
+    }
+
+    public void test_plusMonths_noChange() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertSame(test.plus(0, MONTHS), test);
+        assertEquals(test.plus(LocalPeriod.of(0, MONTHS)), test);
+        assertEquals(test.plus(LocalPeriod.of(Period.of(0, MONTHS))), test);
+    }
+
+    public void test_plusMonths_toZero() {
+        LocalPeriod test = LocalPeriod.of(-1, MONTHS);
+        assertSame(test.plus(1, MONTHS), LocalPeriod.ZERO);
+        assertSame(test.plus(LocalPeriod.of(1, MONTHS)), LocalPeriod.ZERO);
+        assertSame(test.plus(LocalPeriod.of(Period.of(1, MONTHS))), LocalPeriod.ZERO);
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_plusMonths_overflowTooBig() {
+        LocalPeriod test = LocalPeriod.of(Integer.MAX_VALUE, MONTHS);
+        test.plus(1, MONTHS);
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_plusMonths_overflowTooSmall() {
+        LocalPeriod test = LocalPeriod.of(Integer.MIN_VALUE, MONTHS);
+        test.plus(-1, MONTHS);
+    }
+
+    //-----------------------------------------------------------------------
+    // plusDays()
+    //-----------------------------------------------------------------------
+    public void test_plusDays() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertPeriod(test.plus(10, DAYS), 1, 2, 13, 4, 5, 6, 7);
+    }
+
+    public void test_plusDays_noChange() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertSame(test.plus(0, DAYS), test);
+    }
+
+    public void test_plusDays_toZero() {
+        LocalPeriod test = LocalPeriod.of(-1, DAYS);
+        assertSame(test.plus(1, DAYS), LocalPeriod.ZERO);
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_plusDays_overflowTooBig() {
+        LocalPeriod test = LocalPeriod.of(Integer.MAX_VALUE, DAYS);
+        test.plus(1, DAYS);
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_plusDays_overflowTooSmall() {
+        LocalPeriod test = LocalPeriod.of(Integer.MIN_VALUE, DAYS);
+        test.plus(-1, DAYS);
+    }
+
+    //-----------------------------------------------------------------------
+    // plusHours()
+    //-----------------------------------------------------------------------
+    public void test_plusHours() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertPeriod(test.plus(10, HOURS), 1, 2, 3, 14, 5, 6, 7);
+    }
+
+    public void test_plusHours_noChange() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertSame(test.plus(0, HOURS), test);
+    }
+
+    public void test_plusHours_toZero() {
+        LocalPeriod test = LocalPeriod.of(-1, HOURS);
+        assertSame(test.plus(1, HOURS), LocalPeriod.ZERO);
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_plusHours_overflowTooBig() {
+        LocalPeriod test = LocalPeriod.of(Integer.MAX_VALUE, HOURS);
+        test.plus(1, HOURS);
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_plusHours_overflowTooSmall() {
+        LocalPeriod test = LocalPeriod.of(Integer.MIN_VALUE, HOURS);
+        test.plus(-1, HOURS);
+    }
+
+    //-----------------------------------------------------------------------
+    // plusMinutes()
+    //-----------------------------------------------------------------------
+    public void test_plusMinutes() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertPeriod(test.plus(10, MINUTES), 1, 2, 3, 4, 15, 6, 7);
+    }
+
+    public void test_plusMinutes_noChange() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertSame(test.plus(0, MINUTES), test);
+    }
+
+    public void test_plusMinutes_toZero() {
+        LocalPeriod test = LocalPeriod.of(-1, MINUTES);
+        assertSame(test.plus(1, MINUTES), LocalPeriod.ZERO);
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_plusMinutes_overflowTooBig() {
+        LocalPeriod test = LocalPeriod.of(Integer.MAX_VALUE, MINUTES);
+        test.plus(1, MINUTES);
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_plusMinutes_overflowTooSmall() {
+        LocalPeriod test = LocalPeriod.of(Integer.MIN_VALUE, MINUTES);
+        test.plus(-1, MINUTES);
+    }
+
+    //-----------------------------------------------------------------------
+    // plusSeconds()
+    //-----------------------------------------------------------------------
+    public void test_plusSeconds() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertPeriod(test.plus(10, SECONDS), 1, 2, 3, 4, 5, 16, 7);
+    }
+
+    public void test_plusSeconds_noChange() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertSame(test.plus(0, SECONDS), test);
+    }
+
+    public void test_plusSeconds_toZero() {
+        LocalPeriod test = LocalPeriod.of(-1, SECONDS);
+        assertSame(test.plus(1, SECONDS), LocalPeriod.ZERO);
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_plusSeconds_overflowTooBig() {
+        LocalPeriod test = LocalPeriod.of(Integer.MAX_VALUE, SECONDS);
+        test.plus(1, SECONDS);
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_plusSeconds_overflowTooSmall() {
+        LocalPeriod test = LocalPeriod.of(Integer.MIN_VALUE, SECONDS);
+        test.plus(-1, SECONDS);
+    }
+
+    //-----------------------------------------------------------------------
+    // plusNanos()
+    //-----------------------------------------------------------------------
+    public void test_plusNanos() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertPeriod(test.plus(10, NANOS), 1, 2, 3, 4, 5, 6, 17);
+    }
+
+    public void test_plusNanos_noChange() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertSame(test.plus(0, NANOS), test);
+    }
+
+    public void test_plusNanos_toZero() {
+        LocalPeriod test = LocalPeriod.of(-1, NANOS);
+        assertSame(test.plus(1, NANOS), LocalPeriod.ZERO);
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_plusNanos_overflowTooBig() {
+        LocalPeriod test = LocalPeriod.of(Long.MAX_VALUE, NANOS);
+        test.plus(1, NANOS);
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_plusNanos_overflowTooSmall() {
+        LocalPeriod test = LocalPeriod.of(Long.MIN_VALUE, NANOS);
+        test.plus(-1, NANOS);
+    }
+
+    //-----------------------------------------------------------------------
+    // minusYears()
+    //-----------------------------------------------------------------------
+    public void test_minusYears() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertPeriod(test.minus(10, YEARS), -9, 2, 3, 4, 5, 6, 7);
+    }
+
+    public void test_minusYears_noChange() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertSame(test.minus(0, YEARS), test);
+    }
+
+    public void test_minusYears_toZero() {
+        LocalPeriod test = LocalPeriod.of(1, YEARS);
+        assertSame(test.minus(1, YEARS), LocalPeriod.ZERO);
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_minusYears_overflowTooBig() {
+        LocalPeriod test = LocalPeriod.of(Integer.MAX_VALUE, YEARS);
+        test.minus(-1, YEARS);
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_minusYears_overflowTooSmall() {
+        LocalPeriod test = LocalPeriod.of(Integer.MIN_VALUE, YEARS);
+        test.minus(1, YEARS);
+    }
+
+    //-----------------------------------------------------------------------
+    // minusMonths()
+    //-----------------------------------------------------------------------
+    public void test_minusMonths() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertPeriod(test.minus(10, MONTHS), 1, -8, 3, 4, 5, 6, 7);
+    }
+
+    public void test_minusMonths_noChange() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertSame(test.minus(0, MONTHS), test);
+    }
+
+    public void test_minusMonths_toZero() {
+        LocalPeriod test = LocalPeriod.of(1, MONTHS);
+        assertSame(test.minus(1, MONTHS), LocalPeriod.ZERO);
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_minusMonths_overflowTooBig() {
+        LocalPeriod test = LocalPeriod.of(Integer.MAX_VALUE, MONTHS);
+        test.minus(-1, MONTHS);
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_minusMonths_overflowTooSmall() {
+        LocalPeriod test = LocalPeriod.of(Integer.MIN_VALUE, MONTHS);
+        test.minus(1, MONTHS);
+    }
+
+    //-----------------------------------------------------------------------
+    // minusDays()
+    //-----------------------------------------------------------------------
+    public void test_minusDays() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertPeriod(test.minus(10, DAYS), 1, 2, -7, 4, 5, 6, 7);
+    }
+
+    public void test_minusDays_noChange() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertSame(test.minus(0, DAYS), test);
+    }
+
+    public void test_minusDays_toZero() {
+        LocalPeriod test = LocalPeriod.of(1, DAYS);
+        assertSame(test.minus(1, DAYS), LocalPeriod.ZERO);
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_minusDays_overflowTooBig() {
+        LocalPeriod test = LocalPeriod.of(Integer.MAX_VALUE, DAYS);
+        test.minus(-1, DAYS);
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_minusDays_overflowTooSmall() {
+        LocalPeriod test = LocalPeriod.of(Integer.MIN_VALUE, DAYS);
+        test.minus(1, DAYS);
+    }
+
+    //-----------------------------------------------------------------------
+    // minusHours()
+    //-----------------------------------------------------------------------
+    public void test_minusHours() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertPeriod(test.minus(10, HOURS), 1, 2, 3, -6, 5, 6, 7);
+    }
+
+    public void test_minusHours_noChange() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertSame(test.minus(0, HOURS), test);
+    }
+
+    public void test_minusHours_toZero() {
+        LocalPeriod test = LocalPeriod.of(1, HOURS);
+        assertSame(test.minus(1, HOURS), LocalPeriod.ZERO);
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_minusHours_overflowTooBig() {
+        LocalPeriod test = LocalPeriod.of(Integer.MAX_VALUE, HOURS);
+        test.minus(-1, HOURS);
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_minusHours_overflowTooSmall() {
+        LocalPeriod test = LocalPeriod.of(Integer.MIN_VALUE, HOURS);
+        test.minus(1, HOURS);
+    }
+
+    //-----------------------------------------------------------------------
+    // minusMinutes()
+    //-----------------------------------------------------------------------
+    public void test_minusMinutes() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertPeriod(test.minus(10, MINUTES), 1, 2, 3, 4, -5, 6, 7);
+    }
+
+    public void test_minusMinutes_noChange() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertSame(test.minus(0, MINUTES), test);
+    }
+
+    public void test_minusMinutes_toZero() {
+        LocalPeriod test = LocalPeriod.of(1, MINUTES);
+        assertSame(test.minus(1, MINUTES), LocalPeriod.ZERO);
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_minusMinutes_overflowTooBig() {
+        LocalPeriod test = LocalPeriod.of(Integer.MAX_VALUE, MINUTES);
+        test.minus(-1, MINUTES);
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_minusMinutes_overflowTooSmall() {
+        LocalPeriod test = LocalPeriod.of(Integer.MIN_VALUE, MINUTES);
+        test.minus(1, MINUTES);
+    }
+
+    //-----------------------------------------------------------------------
+    // minusSeconds()
+    //-----------------------------------------------------------------------
+    public void test_minusSeconds() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertPeriod(test.minus(10, SECONDS), 1, 2, 3, 4, 5, -4, 7);
+    }
+
+    public void test_minusSeconds_noChange() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertSame(test.minus(0, SECONDS), test);
+    }
+
+    public void test_minusSeconds_toZero() {
+        LocalPeriod test = LocalPeriod.of(1, SECONDS);
+        assertSame(test.minus(1, SECONDS), LocalPeriod.ZERO);
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_minusSeconds_overflowTooBig() {
+        LocalPeriod test = LocalPeriod.of(Integer.MAX_VALUE, SECONDS);
+        test.minus(-1, SECONDS);
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_minusSeconds_overflowTooSmall() {
+        LocalPeriod test = LocalPeriod.of(Integer.MIN_VALUE, SECONDS);
+        test.minus(1, SECONDS);
+    }
+
+    //-----------------------------------------------------------------------
+    // minusNanos()
+    //-----------------------------------------------------------------------
+    public void test_minusNanos() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertPeriod(test.minus(10, NANOS), 1, 2, 3, 4, 5, 6, -3);
+    }
+
+    public void test_minusNanos_noChange() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertSame(test.minus(0, NANOS), test);
+    }
+
+    public void test_minusNanos_toZero() {
+        LocalPeriod test = LocalPeriod.of(1, NANOS);
+        assertSame(test.minus(1, NANOS), LocalPeriod.ZERO);
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_minusNanos_overflowTooBig() {
+        LocalPeriod test = LocalPeriod.of(Long.MAX_VALUE, NANOS);
+        test.minus(-1, NANOS);
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_minusNanos_overflowTooSmall() {
+        LocalPeriod test = LocalPeriod.of(Long.MIN_VALUE, NANOS);
+        test.minus(1, NANOS);
+    }
+
+    //-----------------------------------------------------------------------
+    // multipliedBy()
+    //-----------------------------------------------------------------------
+    public void test_multipliedBy() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertPeriod(test.multipliedBy(2), 2, 4, 6, 8, 10, 12, 14);
+        assertPeriod(test.multipliedBy(-3), -3, -6, -9, -12, -15, -18, -21);
+    }
+
+    public void test_multipliedBy_zeroBase() {
+        assertSame(LocalPeriod.ZERO.multipliedBy(2), LocalPeriod.ZERO);
+    }
+
+    public void test_multipliedBy_zero() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertSame(test.multipliedBy(0), LocalPeriod.ZERO);
+    }
+
+    public void test_multipliedBy_one() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertSame(test.multipliedBy(1), test);
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_multipliedBy_overflowTooBig() {
+        LocalPeriod test = LocalPeriod.of(Integer.MAX_VALUE / 2 + 1, YEARS);
+        test.multipliedBy(2);
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_multipliedBy_overflowTooSmall() {
+        LocalPeriod test = LocalPeriod.of(Integer.MIN_VALUE / 2 - 1, YEARS);
+        test.multipliedBy(2);
+    }
+
+    //-----------------------------------------------------------------------
+    // dividedBy()
+    //-----------------------------------------------------------------------
+    public void test_dividedBy() {
+        LocalPeriod test = LocalPeriod.of(12, 12, 12, 12, 12, 11, 9);
+        assertSame(LocalPeriod.ZERO.dividedBy(2), LocalPeriod.ZERO);
+        assertSame(test.dividedBy(1), test);
+        assertPeriod(test.dividedBy(2), 6, 6, 6, 6, 6, 5, 4);
+        assertPeriod(test.dividedBy(-3), -4, -4, -4, -4, -4, -3, -3);
+    }
+
+    public void test_dividedBy_zeroBase() {
+        assertSame(LocalPeriod.ZERO.dividedBy(2), LocalPeriod.ZERO);
+    }
+
+    public void test_dividedBy_one() {
+        LocalPeriod test = LocalPeriod.of(12, 12, 12, 12, 12, 11, 11);
+        assertSame(test.dividedBy(1), test);
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_dividedBy_divideByZero() {
+        LocalPeriod test = LocalPeriod.of(12, 12, 12, 12, 12, 12, 12);
+        test.dividedBy(0);
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_dividedBy_zeroBase_divideByZero() {
+        LocalPeriod.ZERO.dividedBy(0);
+    }
+
+    //-----------------------------------------------------------------------
+    // negated()
+    //-----------------------------------------------------------------------
+    public void test_negated() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6, 7);
+        assertPeriod(test.negated(), -1, -2, -3, -4, -5, -6, -7);
+    }
+
+    public void test_negated_zero() {
+        assertSame(LocalPeriod.ZERO.negated(), LocalPeriod.ZERO);
+    }
+
+    public void test_negated_max() {
+        assertPeriod(LocalPeriod.of(Integer.MAX_VALUE, YEARS).negated(), -Integer.MAX_VALUE, 0, 0, 0, 0, 0, 0);
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_negated_overflow() {
+        LocalPeriod.of(Integer.MIN_VALUE, YEARS).negated();
+    }
+
+    //-----------------------------------------------------------------------
+    // normalized()
+    //-----------------------------------------------------------------------
+    public void test_normalized() {
+        assertPeriod(LocalPeriod.of(1, 2, 3, 4, 5, 6, 7).normalized(), 1, 2, 3, 4, 5, 6, 7);
+    }
+
+    public void test_normalized_months() {
+        assertPeriod(LocalPeriod.of(1, 11, 3, 4, 5, 6).normalized(), 1, 11, 3, 4, 5, 6, 0);
+        assertPeriod(LocalPeriod.of(1, 12, 3, 4, 5, 6).normalized(), 2, 0, 3, 4, 5, 6, 0);
+        assertPeriod(LocalPeriod.of(1, 23, 3, 4, 5, 6).normalized(), 2, 11, 3, 4, 5, 6, 0);
+        assertPeriod(LocalPeriod.of(1, 24, 3, 4, 5, 6).normalized(), 3, 0, 3, 4, 5, 6, 0);
+        
+        assertPeriod(LocalPeriod.of(3, -2, 3, 4, 5, 6).normalized(), 2, 10, 3, 4, 5, 6, 0);
+    }
+
+    public void test_normalized_nanos() {
+        assertPeriod(LocalPeriod.of(1, 2, 3, 4, 5, 6, 999999999).normalized(), 1, 2, 3, 4, 5, 6, 999999999);
+        assertPeriod(LocalPeriod.of(1, 2, 3, 4, 5, 6, 1000000000).normalized(), 1, 2, 3, 4, 5, 7, 0);
+        
+        assertPeriod(LocalPeriod.of(1, 2, 3, 4, 5, 59, 999999999).normalized(), 1, 2, 3, 4, 5, 59, 999999999);
+        assertPeriod(LocalPeriod.of(1, 2, 3, 4, 5, 59, 1000000000).normalized(), 1, 2, 3, 4, 6, 0, 0);
+        
+        assertPeriod(LocalPeriod.of(1, 2, 3, 4, 59, 59, 999999999).normalized(), 1, 2, 3, 4, 59, 59, 999999999);
+        assertPeriod(LocalPeriod.of(1, 2, 3, 4, 59, 59, 1000000000).normalized(), 1, 2, 3, 5, 0, 0, 0);
+        
+        assertPeriod(LocalPeriod.of(1, 2, 3, 23, 59, 59, 999999999).normalized(), 1, 2, 3, 23, 59, 59, 999999999);
+        assertPeriod(LocalPeriod.of(1, 2, 3, 23, 59, 59, 1000000000).normalized(), 1, 2, 3, 24, 0, 0, 0);
+        
+        assertPeriod(LocalPeriod.of(1, 2, 3, 0, 1, 0, -1).normalized(), 1, 2, 3, 0, 0, 59, 999999999);
+    }
+
+    public void test_normalized_seconds() {
+        assertPeriod(LocalPeriod.of(1, 2, 3, 4, 5, 59).normalized(), 1, 2, 3, 4, 5, 59, 0);
+        assertPeriod(LocalPeriod.of(1, 2, 3, 4, 5, 60).normalized(), 1, 2, 3, 4, 6, 0, 0);
+        assertPeriod(LocalPeriod.of(1, 2, 3, 4, 5, 119).normalized(), 1, 2, 3, 4, 6, 59, 0);
+        assertPeriod(LocalPeriod.of(1, 2, 3, 4, 5, 120).normalized(), 1, 2, 3, 4, 7, 0, 0);
+        
+        assertPeriod(LocalPeriod.of(1, 2, 3, 4, 59, 59).normalized(), 1, 2, 3, 4, 59, 59, 0);
+        assertPeriod(LocalPeriod.of(1, 2, 3, 4, 59, 60).normalized(), 1, 2, 3, 5, 0, 0, 0);
+        
+        assertPeriod(LocalPeriod.of(1, 2, 3, 23, 59, 59).normalized(), 1, 2, 3, 23, 59, 59, 0);
+        assertPeriod(LocalPeriod.of(1, 2, 3, 23, 59, 60).normalized(), 1, 2, 3, 24, 0, 0, 0);
+        
+        assertPeriod(LocalPeriod.of(1, 2, 3, 0, 0, -1).normalized(), 1, 2, 3, -1, 59, 59, 0);
+    }
+
+    public void test_normalized_minutes() {
+        assertPeriod(LocalPeriod.of(1, 2, 3, 4, 59, 6).normalized(), 1, 2, 3, 4, 59, 6, 0);
+        assertPeriod(LocalPeriod.of(1, 2, 3, 4, 60, 6).normalized(), 1, 2, 3, 5, 0, 6, 0);
+        assertPeriod(LocalPeriod.of(1, 2, 3, 4, 119, 6).normalized(), 1, 2, 3, 5, 59, 6, 0);
+        assertPeriod(LocalPeriod.of(1, 2, 3, 4, 120, 6).normalized(), 1, 2, 3, 6, 0, 6, 0);
+        
+        assertPeriod(LocalPeriod.of(1, 2, 3, 23, 59, 6).normalized(), 1, 2, 3, 23, 59, 6, 0);
+        assertPeriod(LocalPeriod.of(1, 2, 3, 23, 60, 6).normalized(), 1, 2, 3, 24, 0, 6, 0);
+        
+        assertPeriod(LocalPeriod.of(1, 2, 3, 23, -1, 0).normalized(), 1, 2, 3, 22, 59, 0, 0);
+        assertPeriod(LocalPeriod.of(1, 2, 3, 23, -1, 60).normalized(), 1, 2, 3, 23, 0, 0, 0);
+    }
+
+    public void test_normalized_hours() {
+        assertPeriod(LocalPeriod.of(1, 2, 3, 23, 5, 6).normalized(), 1, 2, 3, 23, 5, 6, 0);
+        assertPeriod(LocalPeriod.of(1, 2, 3, 24, 5, 6).normalized(), 1, 2, 3, 24, 5, 6, 0);
+    }
+
+    public void test_normalized_zero() {
+        assertSame(LocalPeriod.ZERO.normalized(), LocalPeriod.ZERO);
+    }
+
+    public void test_normalized_bigNanos() {
+        LocalPeriod big = LocalPeriod.of(1, 2, 3, 4, 5, 6, Long.MAX_VALUE);
+        long total = Long.MAX_VALUE;
+        long nanos = total % 1000000000L;
+        total = total / 1000000000L + 6;
+        int secs = (int) (total % 60);
+        total = total / 60 + 5;
+        int mins = (int) (total % 60);
+        total = total / 60 + 4;
+        if (total > Integer.MAX_VALUE) {
+            throw new AssertionError("Bad test");
+        }
+        int hours = (int) total;
+        assertPeriod(big.normalized(), 1, 2, 3, hours, mins, secs, nanos);
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_normalized_max() {
+        LocalPeriod base = LocalPeriod.of(Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE,
+                Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Long.MAX_VALUE);
+        base.normalized();
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_normalized_maxTime() {
+        LocalPeriod base = LocalPeriod.of(0, 0, Integer.MAX_VALUE,
+                Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Long.MAX_VALUE);
+        base.normalized();
+    }
+
+    //-----------------------------------------------------------------------
+    // normalizedWith24HourDays()
+    //-----------------------------------------------------------------------
+    public void test_normalizedWith24HourDays() {
+        assertPeriod(LocalPeriod.of(1, 2, 3, 4, 5, 6).normalizedWith24HourDays(), 1, 2, 3, 4, 5, 6, 0);
+        
+        assertPeriod(LocalPeriod.of(3, -2, 3, 4, 5, 6).normalizedWith24HourDays(), 2, 10, 3, 4, 5, 6, 0);
+    }
+
+    public void test_normalizedWith24HourDays_months() {
+        assertPeriod(LocalPeriod.of(1, 11, 3, 4, 5, 6).normalizedWith24HourDays(), 1, 11, 3, 4, 5, 6, 0);
+        assertPeriod(LocalPeriod.of(1, 12, 3, 4, 5, 6).normalizedWith24HourDays(), 2, 0, 3, 4, 5, 6, 0);
+        assertPeriod(LocalPeriod.of(1, 23, 3, 4, 5, 6).normalizedWith24HourDays(), 2, 11, 3, 4, 5, 6, 0);
+        assertPeriod(LocalPeriod.of(1, 24, 3, 4, 5, 6).normalizedWith24HourDays(), 3, 0, 3, 4, 5, 6, 0);
+    }
+
+    public void test_normalizedWith24HourDays_nanos() {
+        assertPeriod(LocalPeriod.of(1, 2, 3, 4, 5, 6, 999999999).normalizedWith24HourDays(), 1, 2, 3, 4, 5, 6, 999999999);
+        assertPeriod(LocalPeriod.of(1, 2, 3, 4, 5, 6, 1000000000).normalizedWith24HourDays(), 1, 2, 3, 4, 5, 7, 0);
+        
+        assertPeriod(LocalPeriod.of(1, 2, 3, 4, 5, 59, 999999999).normalizedWith24HourDays(), 1, 2, 3, 4, 5, 59, 999999999);
+        assertPeriod(LocalPeriod.of(1, 2, 3, 4, 5, 59, 1000000000).normalizedWith24HourDays(), 1, 2, 3, 4, 6, 0, 0);
+        
+        assertPeriod(LocalPeriod.of(1, 2, 3, 4, 59, 59, 999999999).normalizedWith24HourDays(), 1, 2, 3, 4, 59, 59, 999999999);
+        assertPeriod(LocalPeriod.of(1, 2, 3, 4, 59, 59, 1000000000).normalizedWith24HourDays(), 1, 2, 3, 5, 0, 0, 0);
+        
+        assertPeriod(LocalPeriod.of(1, 2, 3, 23, 59, 59, 999999999).normalizedWith24HourDays(), 1, 2, 3, 23, 59, 59, 999999999);
+        assertPeriod(LocalPeriod.of(1, 2, 3, 23, 59, 59, 1000000000).normalizedWith24HourDays(), 1, 2, 4, 0, 0, 0, 0);
+    }
+
+    public void test_normalizedWith24HourDays_seconds() {
+        assertPeriod(LocalPeriod.of(1, 2, 3, 4, 5, 59).normalizedWith24HourDays(), 1, 2, 3, 4, 5, 59, 0);
+        assertPeriod(LocalPeriod.of(1, 2, 3, 4, 5, 60).normalizedWith24HourDays(), 1, 2, 3, 4, 6, 0, 0);
+        assertPeriod(LocalPeriod.of(1, 2, 3, 4, 5, 119).normalizedWith24HourDays(), 1, 2, 3, 4, 6, 59, 0);
+        assertPeriod(LocalPeriod.of(1, 2, 3, 4, 5, 120).normalizedWith24HourDays(), 1, 2, 3, 4, 7, 0, 0);
+        
+        assertPeriod(LocalPeriod.of(1, 2, 3, 4, 59, 59).normalizedWith24HourDays(), 1, 2, 3, 4, 59, 59, 0);
+        assertPeriod(LocalPeriod.of(1, 2, 3, 4, 59, 60).normalizedWith24HourDays(), 1, 2, 3, 5, 0, 0, 0);
+        
+        assertPeriod(LocalPeriod.of(1, 2, 3, 23, 59, 59).normalizedWith24HourDays(), 1, 2, 3, 23, 59, 59, 0);
+        assertPeriod(LocalPeriod.of(1, 2, 3, 23, 59, 60).normalizedWith24HourDays(), 1, 2, 4, 0, 0, 0, 0);
+        
+        assertPeriod(LocalPeriod.of(1, 2, 3, 0, 0, -1).normalizedWith24HourDays(), 1, 2, 2, 23, 59, 59, 0);
+    }
+
+    public void test_normalizedWith24HourDays_minutes() {
+        assertPeriod(LocalPeriod.of(1, 2, 3, 4, 59, 6).normalizedWith24HourDays(), 1, 2, 3, 4, 59, 6, 0);
+        assertPeriod(LocalPeriod.of(1, 2, 3, 4, 60, 6).normalizedWith24HourDays(), 1, 2, 3, 5, 0, 6, 0);
+        assertPeriod(LocalPeriod.of(1, 2, 3, 4, 119, 6).normalizedWith24HourDays(), 1, 2, 3, 5, 59, 6, 0);
+        assertPeriod(LocalPeriod.of(1, 2, 3, 4, 120, 6).normalizedWith24HourDays(), 1, 2, 3, 6, 0, 6, 0);
+        
+        assertPeriod(LocalPeriod.of(1, 2, 3, 23, 59, 6).normalizedWith24HourDays(), 1, 2, 3, 23, 59, 6, 0);
+        assertPeriod(LocalPeriod.of(1, 2, 3, 23, 60, 6).normalizedWith24HourDays(), 1, 2, 4, 0, 0, 6, 0);
+        
+        assertPeriod(LocalPeriod.of(1, 2, 3, 23, -1, 0).normalizedWith24HourDays(), 1, 2, 3, 22, 59, 0, 0);
+        assertPeriod(LocalPeriod.of(1, 2, 3, 23, -1, 60).normalizedWith24HourDays(), 1, 2, 3, 23, 0, 0, 0);
+    }
+
+    public void test_normalizedWith24HourDays_hours() {
+        assertPeriod(LocalPeriod.of(1, 2, 3, 23, 5, 6).normalizedWith24HourDays(), 1, 2, 3, 23, 5, 6, 0);
+        assertPeriod(LocalPeriod.of(1, 2, 3, 24, 5, 6).normalizedWith24HourDays(), 1, 2, 4, 0, 5, 6, 0);
+        assertPeriod(LocalPeriod.of(1, 2, 3, 47, 5, 6).normalizedWith24HourDays(), 1, 2, 4, 23, 5, 6, 0);
+        assertPeriod(LocalPeriod.of(1, 2, 3, 48, 5, 6).normalizedWith24HourDays(), 1, 2, 5, 0, 5, 6, 0);
+    }
+
+    public void test_normalizedWith24HourDays_zero() {
+        assertSame(LocalPeriod.ZERO.normalizedWith24HourDays(), LocalPeriod.ZERO);
+    }
+
+    public void test_normalizedWith24HourDays_bigNanos() {
+        LocalPeriod big = LocalPeriod.of(1, 2, 3, 4, 5, 6, Long.MAX_VALUE);
+        long total = Long.MAX_VALUE;
+        long nanos = total % 1000000000L;
+        total = total / 1000000000L + 6;
+        int secs = (int) (total % 60);
+        total = total / 60 + 5;
+        int mins = (int) (total % 60);
+        total = total / 60 + 4;
+        int hours = (int) (total % 24);
+        total = total / 24 + 3;
+        if (total > Integer.MAX_VALUE) {
+            throw new AssertionError("Bad test");
+        }
+        int days = (int) total;
+        assertPeriod(big.normalizedWith24HourDays(), 1, 2, days, hours, mins, secs, nanos);
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_normalizedWith24HourDays_max() {
+        LocalPeriod base = LocalPeriod.of(Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE,
+                Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Long.MAX_VALUE);
+        base.normalizedWith24HourDays();
+    }
+
+    @Test(expectedExceptions=ArithmeticException.class)
+    public void test_normalizedWith24HourDays_maxTime() {
+        LocalPeriod base = LocalPeriod.of(0, 0, Integer.MAX_VALUE,
+                Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Long.MAX_VALUE);
+        base.normalizedWith24HourDays();
+    }
+
+
+    //-----------------------------------------------------------------------
+    // toDuration()
+    //-----------------------------------------------------------------------
+    public void test_toEstimatedDuration() {
+        assertEquals(LocalPeriod.ZERO.toDuration(), Duration.of(0, TimeUnit.SECONDS));
+        assertEquals(LocalPeriod.of(0, 0, 0, 4, 5, 6, 7).toDuration(), Duration.ofSeconds((4 * 60 + 5) * 60L + 6, 7));
+        assertEquals(LocalPeriod.of(0, 0, 0, -4, -5, -6, -7).toDuration(), Duration.ofSeconds((-4 * 60 - 5) * 60L - 6, -7));
+    }
+
+    public void test_toEstimatedDuration_Days() {
+        assertEquals(LocalPeriod.ZERO.toDuration(), Duration.of(0, TimeUnit.SECONDS));
+        assertEquals(LocalPeriod.of(2, DAYS).toDuration(), LocalPeriodUnit.DAYS.getDuration().multipliedBy(2));
+    }
+
+    //-----------------------------------------------------------------------
+    // toDuration()
+    //-----------------------------------------------------------------------
+    public void test_toDuration() {
+        assertEquals(LocalPeriod.ZERO.toDuration(), Duration.of(0, TimeUnit.SECONDS));
+        assertEquals(LocalPeriod.of(0, 0, 0, 4, 5, 6, 7).toDuration(), Duration.ofSeconds((4 * 60 + 5) * 60L + 6, 7));
+    }
+
+    public void test_toDuration_calculation() {
+        assertEquals(LocalPeriod.of(0, 0, 2, 0, 0, 0, 0).toDuration(), Duration.ofSeconds(2 * 24 * 3600));
+        assertEquals(LocalPeriod.of(0, 0, 0, 2, 0, 0, 0).toDuration(), Duration.ofSeconds(2 * 3600));
+        assertEquals(LocalPeriod.of(0, 0, 0, 0, 2, 0, 0).toDuration(), Duration.of(120, TimeUnit.SECONDS));
+        assertEquals(LocalPeriod.of(0, 0, 0, 0, 0, 2, 0).toDuration(), Duration.of(2, TimeUnit.SECONDS));
+        
+        assertEquals(LocalPeriod.of(0, 0, 0, 0, 0, 3, 1000000000L - 1).toDuration(), Duration.ofSeconds(3, 999999999));
+        assertEquals(LocalPeriod.of(0, 0, 0, 0, 0, 3, 1000000000L).toDuration(), Duration.ofSeconds(4, 0));
+    }
+
+    public void test_toDuration_negatives() {
+        assertEquals(LocalPeriod.of(0, 0, 0, 0, 0, 2, 1).toDuration(), Duration.ofSeconds(2, 1));
+        assertEquals(LocalPeriod.of(0, 0, 0, 0, 0, 2, -1).toDuration(), Duration.ofSeconds(1, 999999999));
+        assertEquals(LocalPeriod.of(0, 0, 0, 0, 0, -2, 1).toDuration(), Duration.ofSeconds(-2, 1));
+        assertEquals(LocalPeriod.of(0, 0, 0, 0, 0, -2, -1).toDuration(), Duration.ofSeconds(-3, 999999999));
+    }
+
+    public void test_toDuration_big() {
+        BigInteger calc = BigInteger.valueOf(Long.MAX_VALUE).divide(BINT_1BN)
+                            .add(MAX_BINT)
+                            .add(MAX_BINT.multiply(BINT_60).add(MAX_BINT).multiply(BINT_60));
+        long s = new BigDecimal(calc).longValueExact();
+        calc = BigInteger.valueOf(Long.MAX_VALUE).remainder(BINT_1BN);
+        int n = new BigDecimal(calc).intValueExact();
+        LocalPeriod test = LocalPeriod.of(0, 0, 0, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Long.MAX_VALUE);
+        assertEquals(test.toDuration(), Duration.ofSeconds(s, n));
+
+        calc = BigInteger.valueOf(Long.MAX_VALUE).divide(BINT_1BN)
+                            .add(MAX_BINT)
+                            .add(MAX_BINT.multiply(BINT_24).add(MAX_BINT).multiply(BINT_60).add(MAX_BINT).multiply(BINT_60));
+        s = new BigDecimal(calc).longValueExact();
+        calc = BigInteger.valueOf(Long.MAX_VALUE).remainder(BINT_1BN);
+        n = new BigDecimal(calc).intValueExact();
+        test = LocalPeriod.of(0, 0, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Long.MAX_VALUE);
+        assertEquals(test.toDuration(), Duration.ofSeconds(s, n));
+    }
+
+    @Test(expectedExceptions=CalendricalException.class)
+    public void test_toDuration_years() {
+        LocalPeriod.of(1, 0, 0, 4, 5, 6, 7).toDuration();
+    }
+
+    @Test(expectedExceptions=CalendricalException.class)
+    public void test_toDuration_months() {
+        LocalPeriod.of(0, 1, 0, 4, 5, 6, 7).toDuration();
+    }
+
+    @Test()
+    public void test_toDuration_days() {
+        Duration test = LocalPeriod.of(0, 0, 1, 4, 5, 6, 7).toDuration();
+        assertEquals(test, Duration.ofSeconds(101106, 7L));
+    }
+
+    //-----------------------------------------------------------------------
+    // equals() / hashCode()
+    //-----------------------------------------------------------------------
+    public void test_equals() {
+        assertEquals(LocalPeriod.of(1, 0, 0, 0, 0, 0).equals(LocalPeriod.of(1, YEARS)), true);
+        assertEquals(LocalPeriod.of(0, 1, 0, 0, 0, 0).equals(LocalPeriod.of(1, MONTHS)), true);
+        assertEquals(LocalPeriod.of(0, 0, 1, 0, 0, 0).equals(LocalPeriod.of(1, DAYS)), true);
+        assertEquals(LocalPeriod.of(0, 0, 0, 1, 0, 0).equals(LocalPeriod.of(1, HOURS)), true);
+        assertEquals(LocalPeriod.of(0, 0, 0, 0, 1, 0).equals(LocalPeriod.of(1, MINUTES)), true);
+        assertEquals(LocalPeriod.of(0, 0, 0, 0, 0, 1).equals(LocalPeriod.of(1, SECONDS)), true);
+        assertEquals(LocalPeriod.of(1, 2, 3, 0, 0, 0).equals(LocalPeriod.ofDate(1, 2, 3)), true);
+        assertEquals(LocalPeriod.of(0, 0, 0, 1, 2, 3).equals(LocalPeriod.ofTime(1, 2, 3)), true);
+        assertEquals(LocalPeriod.of(1, 2, 3, 4, 5, 6).equals(LocalPeriod.of(1, 2, 3, 4, 5, 6)), true);
+        
+        assertEquals(LocalPeriod.of(1, YEARS).equals(LocalPeriod.of(1, YEARS)), true);
+        assertEquals(LocalPeriod.of(1, YEARS).equals(LocalPeriod.of(2, YEARS)), false);
+        
+        assertEquals(LocalPeriod.of(1, MONTHS).equals(LocalPeriod.of(1, MONTHS)), true);
+        assertEquals(LocalPeriod.of(1, MONTHS).equals(LocalPeriod.of(2, MONTHS)), false);
+        
+        assertEquals(LocalPeriod.of(1, DAYS).equals(LocalPeriod.of(1, DAYS)), true);
+        assertEquals(LocalPeriod.of(1, DAYS).equals(LocalPeriod.of(2, DAYS)), false);
+        
+        assertEquals(LocalPeriod.of(1, HOURS).equals(LocalPeriod.of(1, HOURS)), true);
+        assertEquals(LocalPeriod.of(1, HOURS).equals(LocalPeriod.of(2, HOURS)), false);
+        
+        assertEquals(LocalPeriod.of(1, MINUTES).equals(LocalPeriod.of(1, MINUTES)), true);
+        assertEquals(LocalPeriod.of(1, MINUTES).equals(LocalPeriod.of(2, MINUTES)), false);
+        
+        assertEquals(LocalPeriod.of(1, SECONDS).equals(LocalPeriod.of(1, SECONDS)), true);
+        assertEquals(LocalPeriod.of(1, SECONDS).equals(LocalPeriod.of(2, SECONDS)), false);
+        
+        assertEquals(LocalPeriod.ofDate(1, 2, 3).equals(LocalPeriod.ofDate(1, 2, 3)), true);
+        assertEquals(LocalPeriod.ofDate(1, 2, 3).equals(LocalPeriod.ofDate(0, 2, 3)), false);
+        assertEquals(LocalPeriod.ofDate(1, 2, 3).equals(LocalPeriod.ofDate(1, 0, 3)), false);
+        assertEquals(LocalPeriod.ofDate(1, 2, 3).equals(LocalPeriod.ofDate(1, 2, 0)), false);
+        
+        assertEquals(LocalPeriod.ofTime(1, 2, 3).equals(LocalPeriod.ofTime(1, 2, 3)), true);
+        assertEquals(LocalPeriod.ofTime(1, 2, 3).equals(LocalPeriod.ofTime(0, 2, 3)), false);
+        assertEquals(LocalPeriod.ofTime(1, 2, 3).equals(LocalPeriod.ofTime(1, 0, 3)), false);
+        assertEquals(LocalPeriod.ofTime(1, 2, 3).equals(LocalPeriod.ofTime(1, 2, 0)), false);
+    }
+
+    public void test_equals_self() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6);
+        assertEquals(test.equals(test), true);
+    }
+
+    public void test_equals_null() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6);
+        assertEquals(test.equals(null), false);
+    }
+
+    public void test_equals_otherClass() {
+        LocalPeriod test = LocalPeriod.of(1, 2, 3, 4, 5, 6);
+        assertEquals(test.equals(""), false);
+    }
+
+    //-----------------------------------------------------------------------
+    public void test_hashCode() {
+        LocalPeriod test5 = LocalPeriod.of(5, DAYS);
+        LocalPeriod test6 = LocalPeriod.of(6, DAYS);
+        assertEquals(test5.hashCode() == test5.hashCode(), true);
+        assertEquals(test5.hashCode() == test6.hashCode(), false);
+    }
+
+    public void test_hashCode_unique_workaroundSlowTest() {
+        // spec requires unique hash codes
+        // years 0-31, months 0-11, days 0-31, hours 0-23, minutes 0-59, seconds 0-59
+        
+        // -37 nanos removes the effect of the nanos
+        int yearsBits = 0;
+        for (int i = 0; i <= 31; i++) {
+            LocalPeriod test = LocalPeriod.of(i, YEARS).withNanos(-37);
+            yearsBits |= test.hashCode();
+        }
+        assertEquals(Integer.bitCount(yearsBits), 5);
+        int monthsBits = 0;
+        for (int i = 0; i <= 11; i++) {
+            LocalPeriod test = LocalPeriod.of(i, MONTHS).withNanos(-37);
+            monthsBits |= test.hashCode();
+        }
+        assertEquals(Integer.bitCount(monthsBits), 4);
+        assertEquals(yearsBits & monthsBits, 0);
+        int daysBits = 0;
+        for (int i = 0; i <= 31; i++) {
+            LocalPeriod test = LocalPeriod.of(i, DAYS).withNanos(-37);
+            daysBits |= test.hashCode();
+        }
+        assertEquals(Integer.bitCount(daysBits), 5);
+        assertEquals(yearsBits & monthsBits & daysBits, 0);
+        int hoursBits = 0;
+        for (int i = 0; i <= 23; i++) {
+            LocalPeriod test = LocalPeriod.of(i, HOURS).withNanos(-37);
+            hoursBits |= test.hashCode();
+        }
+        assertEquals(Integer.bitCount(hoursBits), 5);
+        assertEquals(yearsBits & monthsBits & daysBits & hoursBits, 0);
+        int minutesBits = 0;
+        for (int i = 0; i <= 59; i++) {
+            LocalPeriod test = LocalPeriod.of(i, MINUTES).withNanos(-37);
+            minutesBits |= test.hashCode();
+        }
+        assertEquals(Integer.bitCount(minutesBits), 6);
+        assertEquals(yearsBits & minutesBits & daysBits & hoursBits & minutesBits, 0);
+        int secondsBits = 0;
+        for (int i = 0; i <= 59; i++) {
+            LocalPeriod test = LocalPeriod.of(i, SECONDS).withNanos(-37);
+            secondsBits |= test.hashCode();
+        }
+        assertEquals(Integer.bitCount(secondsBits), 6);
+        assertEquals(yearsBits & secondsBits & daysBits & hoursBits & minutesBits & secondsBits, 0);
+        
+        // make common overflows not same hash code
+        assertTrue(LocalPeriod.of(16, MONTHS).hashCode() != LocalPeriod.of(1, YEARS).hashCode());
+        assertTrue(LocalPeriod.of(32, DAYS).hashCode() != LocalPeriod.of(1, MONTHS).hashCode());
+        assertTrue(LocalPeriod.of(32, HOURS).hashCode() != LocalPeriod.of(1, DAYS).hashCode());
+        assertTrue(LocalPeriod.of(64, MINUTES).hashCode() != LocalPeriod.of(1, HOURS).hashCode());
+        assertTrue(LocalPeriod.of(64, SECONDS).hashCode() != LocalPeriod.of(1, MINUTES).hashCode());
+    }
+
+    //-----------------------------------------------------------------------
+    // toString()
+    //-----------------------------------------------------------------------
+    @DataProvider(name="toStringAndParse")
+    Object[][] data_toString() {
+        return new Object[][] {
+            {LocalPeriod.ZERO, "PT0S"},
+            {LocalPeriod.of(0, DAYS), "PT0S"},
+            {LocalPeriod.of(1, YEARS), "P1Y"},
+            {LocalPeriod.of(1, MONTHS), "P1M"},
+            {LocalPeriod.of(1, DAYS), "P1D"},
+            {LocalPeriod.of(1, HOURS), "PT1H"},
+            {LocalPeriod.of(1, MINUTES), "PT1M"},
+            {LocalPeriod.of(1, SECONDS), "PT1S"},
+            {LocalPeriod.of(1, 2, 3, 4, 5, 6), "P1Y2M3DT4H5M6S"},
+            {LocalPeriod.of(1, 2, 3, 4, 5, 6, 700000000), "P1Y2M3DT4H5M6.7S"},
+            {LocalPeriod.of(0, 0, 0, 0, 0, 0, 100000000), "PT0.1S"},
+            {LocalPeriod.of(0, 0, 0, 0, 0, 0, -100000000), "PT-0.1S"},
+            {LocalPeriod.of(0, 0, 0, 0, 0, 1, -900000000), "PT0.1S"},
+            {LocalPeriod.of(0, 0, 0, 0, 0, -1, 900000000), "PT-0.1S"},
+            {LocalPeriod.of(0, 0, 0, 0, 0, 1, 100000000), "PT1.1S"},
+            {LocalPeriod.of(0, 0, 0, 0, 0, 1, -100000000), "PT0.9S"},
+            {LocalPeriod.of(0, 0, 0, 0, 0, -1, 100000000), "PT-0.9S"},
+            {LocalPeriod.of(0, 0, 0, 0, 0, -1, -100000000), "PT-1.1S"},
+            {LocalPeriod.of(0, 0, 0, 0, 0, 0, 10000000), "PT0.01S"},
+            {LocalPeriod.of(0, 0, 0, 0, 0, 0, -10000000), "PT-0.01S"},
+            {LocalPeriod.of(0, 0, 0, 0, 0, 0, 1000000), "PT0.001S"},
+            {LocalPeriod.of(0, 0, 0, 0, 0, 0, -1000000), "PT-0.001S"},
+            {LocalPeriod.of(0, 0, 0, 0, 0, 0, 1000), "PT0.000001S"},
+            {LocalPeriod.of(0, 0, 0, 0, 0, 0, -1000), "PT-0.000001S"},
+            {LocalPeriod.of(0, 0, 0, 0, 0, 0, 1), "PT0.000000001S"},
+            {LocalPeriod.of(0, 0, 0, 0, 0, 0, -1), "PT-0.000000001S"},
+        };
+    }
+
+    //-----------------------------------------------------------------------
+    private void assertPeriod(LocalPeriod test, int y, int mo, int d, int h, int mn, int s, long n) {
+        assertEquals(test.getYears(), y, "years");
+        assertEquals(test.getMonths(), mo, "months");
+        assertEquals(test.getDays(), d, "days");
+        assertEquals(test.getHours(), h, "hours");
+        assertEquals(test.getMinutes(), mn, "mins");
+        assertEquals(test.getSeconds(), s, "secs");
+        assertEquals(test.getNanos(), n, "nanos");
+    }
+
+}

--- a/src/test/java/javax/time/TestLocalPeriodParser.java
+++ b/src/test/java/javax/time/TestLocalPeriodParser.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2009-2011, Stephen Colebourne & Michael Nascimento Santos
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of JSR-310 nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package javax.time;
+
+import static org.testng.Assert.assertEquals;
+
+import javax.time.format.CalendricalParseException;
+import static javax.time.calendrical.LocalPeriodUnit.YEARS;
+import static javax.time.calendrical.LocalPeriodUnit.MONTHS;
+import static javax.time.calendrical.LocalPeriodUnit.DAYS;
+import static javax.time.calendrical.LocalPeriodUnit.HOURS;
+import static javax.time.calendrical.LocalPeriodUnit.MINUTES;
+import static javax.time.calendrical.LocalPeriodUnit.SECONDS;
+import static javax.time.calendrical.LocalPeriodUnit.NANOS;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Test PeriodParser.
+ *
+ * @author Darryl West
+ * @author Stephen Colebourne
+ */
+@Test 
+public class TestLocalPeriodParser {
+
+    //-----------------------------------------------------------------------
+    // parse(String)
+    //-----------------------------------------------------------------------
+    @DataProvider(name="Parse")
+    Object[][] provider_factory_parse() {
+        return new Object[][] {
+            {"Pt0S", LocalPeriod.ZERO},
+            {"pT0S", LocalPeriod.ZERO},
+            {"PT0S", LocalPeriod.ZERO},
+            {"Pt0s", LocalPeriod.ZERO},
+            {"pt0s", LocalPeriod.ZERO},
+            {"P0Y0M0DT0H0M0.0S", LocalPeriod.ZERO},
+            
+            {"P1Y", LocalPeriod.of(1, YEARS)},
+            {"P100Y", LocalPeriod.of(100, YEARS)},
+            {"P-25Y", LocalPeriod.of(-25, YEARS)},
+            {"P" + Integer.MAX_VALUE + "Y", LocalPeriod.of(Integer.MAX_VALUE, YEARS)},
+            {"P" + Integer.MIN_VALUE + "Y", LocalPeriod.of(Integer.MIN_VALUE, YEARS)},
+            
+            {"P1M", LocalPeriod.of(1, MONTHS)},
+            {"P0M", LocalPeriod.of(0, MONTHS)},
+            {"P-1M", LocalPeriod.of(-1, MONTHS)},
+            {"P" + Integer.MAX_VALUE + "M", LocalPeriod.of(Integer.MAX_VALUE, MONTHS)},
+            {"P" + Integer.MIN_VALUE + "M", LocalPeriod.of(Integer.MIN_VALUE, MONTHS)},
+            
+            {"P1D", LocalPeriod.of(1, DAYS)},
+            {"P0D", LocalPeriod.of(0, DAYS)},
+            {"P-1D", LocalPeriod.of(-1, DAYS)},
+            {"P" + Integer.MAX_VALUE + "D", LocalPeriod.of(Integer.MAX_VALUE, DAYS)},
+            {"P" + Integer.MIN_VALUE + "D", LocalPeriod.of(Integer.MIN_VALUE, DAYS)},
+            
+            {"P2Y3M25D", LocalPeriod.ofDate(2, 3, 25)},
+            
+            {"PT1H", LocalPeriod.of(1, HOURS)},
+            {"PT-1H", LocalPeriod.of(-1, HOURS)},
+            {"PT24H", LocalPeriod.of(24, HOURS)},
+            {"PT-24H", LocalPeriod.of(-24, HOURS)},
+            {"PT" + Integer.MAX_VALUE + "H", LocalPeriod.of(Integer.MAX_VALUE, HOURS)},
+            {"PT" + Integer.MIN_VALUE + "H", LocalPeriod.of(Integer.MIN_VALUE, HOURS)},
+            
+            {"PT1M", LocalPeriod.of(1, MINUTES)},
+            {"PT-1M", LocalPeriod.of(-1, MINUTES)},
+            {"PT60M", LocalPeriod.of(60, MINUTES)},
+            {"PT-60M", LocalPeriod.of(-60, MINUTES)},
+            {"PT" + Integer.MAX_VALUE + "M", LocalPeriod.of(Integer.MAX_VALUE, MINUTES)},
+            {"PT" + Integer.MIN_VALUE + "M", LocalPeriod.of(Integer.MIN_VALUE, MINUTES)},
+            
+            {"PT1S", LocalPeriod.of(1, SECONDS)},
+            {"PT-1S", LocalPeriod.of(-1, SECONDS)},
+            {"PT60S", LocalPeriod.of(60, SECONDS)},
+            {"PT-60S", LocalPeriod.of(-60, SECONDS)},
+            {"PT" + Integer.MAX_VALUE + "S", LocalPeriod.of(Integer.MAX_VALUE, SECONDS)},
+            {"PT" + Integer.MIN_VALUE + "S", LocalPeriod.of(Integer.MIN_VALUE, SECONDS)},
+            
+            {"PT0.1S", LocalPeriod.of( 0, 0, 0, 0, 0, 0, 100000000 ) },
+            {"PT-0.1S", LocalPeriod.of( 0, 0, 0, 0, 0, 0, -100000000 ) },
+            {"PT1.1S", LocalPeriod.of( 0, 0, 0, 0, 0, 1, 100000000 ) },
+            {"PT-1.1S", LocalPeriod.of( 0, 0, 0, 0, 0, -1, -100000000 ) },
+            {"PT1.0001S", LocalPeriod.of(1, SECONDS).plus( 100000, NANOS ) },
+            {"PT1.0000001S", LocalPeriod.of(1, SECONDS).plus( 100, NANOS ) },
+            {"PT1.123456789S", LocalPeriod.of( 0, 0, 0, 0, 0, 1, 123456789 ) },
+            {"PT1.999999999S", LocalPeriod.of( 0, 0, 0, 0, 0, 1, 999999999 ) },
+
+        };
+    }
+
+    @Test(dataProvider="Parse")
+    public void factory_parse(String text, LocalPeriod expected) {
+    	LocalPeriod p = LocalPeriod.parse(text);
+        assertEquals(p, expected);
+    }
+
+    @Test(dataProvider="Parse")
+    public void factory_parse_comma(String text, LocalPeriod expected) {
+    	if (text.contains(".")) {
+    		text = text.replace('.', ',');
+    		LocalPeriod p = LocalPeriod.parse(text);
+        	assertEquals(p, expected);
+    	}
+    }
+
+    @DataProvider(name="ParseFailures")
+    Object[][] provider_factory_parseFailures() {
+        return new Object[][] {
+            {"", 0},
+            {"PTS", 2},
+            {"AT0S", 0},
+            {"PA0S", 1},
+            {"PT0A", 3},
+            
+            {"PT+S", 2},
+            {"PT-S", 2},
+            {"PT.S", 2},
+            {"PTAS", 2},
+            
+            {"PT+0S", 2},
+            {"PT-0S", 2},
+            {"PT+1S", 2},
+            {"PT-.S", 2},
+            
+            {"PT1ABC2S", 3},
+            {"PT1.1ABC2S", 5},
+            
+            {"PT123456789123456789123456789S", 2},
+            {"PT0.1234567891S", 4},
+            {"PT1.S", 2},
+            {"PT.1S", 2},
+            
+            {"PT2.-3S", 2},
+            {"PT-2.-3S", 2},
+            
+            {"P1Y1MT1DT1M1S", 7},
+            {"P1Y1MT1HT1M1S", 8},
+            {"P1YMD", 3},
+            {"PT1ST1D", 4},
+            {"P1Y2Y", 4},
+            {"PT1M+3S", 4},
+            
+            {"PT1S1", 4},
+            {"PT1S.", 4},
+            {"PT1SA", 4},
+            {"PT1M1", 4},
+            {"PT1M.", 4},
+            {"PT1MA", 4},
+        };
+    }
+
+    @Test(dataProvider="ParseFailures", expectedExceptions=CalendricalParseException.class)
+    public void factory_parseFailures(String text, int errPos) {
+        try {
+            LocalPeriod.parse(text);
+        } catch (CalendricalParseException ex) {
+            assertEquals(ex.getParsedString(), text);
+            assertEquals(ex.getErrorIndex(), errPos);
+            System.out.println(ex.toString());
+            throw ex;
+        }
+    }
+
+    @Test(dataProvider="ParseFailures", expectedExceptions=CalendricalParseException.class)
+    public void factory_parseFailures_comma(String text, int errPos) {
+        text = text.replace('.', ',');
+        try {
+            LocalPeriod.parse(text);
+        } catch (CalendricalParseException ex) {
+            assertEquals(ex.getParsedString(), text);
+            assertEquals(ex.getErrorIndex(), errPos);
+            throw ex;
+        }
+    }
+
+    @Test(expectedExceptions=CalendricalParseException.class)
+    public void factory_parse_tooBig() {
+    	String text = "PT" + Long.MAX_VALUE + "1S";
+    	LocalPeriod.parse(text);
+    }
+
+    @Test(expectedExceptions=CalendricalParseException.class)
+    public void factory_parse_tooBig_decimal() {
+    	String text = "PT" + Long.MAX_VALUE + "1.1S";
+    	LocalPeriod.parse(text);
+    }
+
+    @Test(expectedExceptions=CalendricalParseException.class)
+    public void factory_parse_tooSmall() {
+        String text = "PT" + Long.MIN_VALUE + "1S";
+        LocalPeriod.parse(text);
+    }
+
+    @Test(expectedExceptions=CalendricalParseException.class)
+    public void factory_parse_tooSmall_decimal() {
+        String text = "PT" + Long.MIN_VALUE + ".1S";
+        LocalPeriod.parse(text);
+    }
+
+    @Test(expectedExceptions=NullPointerException.class)
+    public void factory_parse_null() {
+    	LocalPeriod.parse(null);
+    }
+
+    @DataProvider(name="ParseSequenceFailures")
+    Object[][] provider_factory_parseSequenceFailures() {
+        return new Object[][] {
+        	{"P0M0Y0DT0H0M0.0S"},
+        	{"P0M0D0YT0H0M0.0S"},
+        	{"P0S0D0YT0S0M0.0H"},
+        	{"PT0M0H0.0S"},
+        	{"PT0M0H"},
+        	{"PT0S0M"},
+        	{"PT0.0M2S"},
+        };
+    }
+
+    @Test(dataProvider="ParseSequenceFailures", expectedExceptions=CalendricalParseException.class)
+    public void factory_parse_badSequence(String text) {
+    	LocalPeriod.parse(text);
+    }
+
+}


### PR DESCRIPTION
Implement multi-unit Period to match the existing single unit Period.
Includes of(Period), plus(Period), minus(Period)  and between methods for DateTime.  
Simplifies API to meet the requirements to be able to store an SQL date.
