### PR TITLE
Remove OpenJDK Licence copy

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -365,7 +365,6 @@
         <copy file="build.properties" todir="${dist.workarea}" />
         <copy file="checkstyle.xml" todir="${dist.workarea}" />
         <copy file="LICENSE.txt" todir="${dist.workarea}" />
-        <copy file="LICENSE_OpenJDK.txt" todir="${dist.workarea}" />
         <copy file="README.txt" todir="${dist.workarea}" />
         <copy file="TODO.txt" todir="${dist.workarea}" />
         <zip destfile="${dist}/${distFileName}" basedir="${dist.workarea}" />


### PR DESCRIPTION
OpenJDK Licence file has been removed from repo. Actually build file is not usable and throws exception!
